### PR TITLE
Resource API should only support (path, offset) tuple list

### DIFF
--- a/README.dev
+++ b/README.dev
@@ -1,3 +1,15 @@
+Prerequisites
+=============
+
+For Fedora/CentOS install the following packages:
+
+   $ sudo yum install -y gcc make libaio-devel libblkid-devel
+
+For Ubuntu/Debian install the following packages:
+
+   $ sudo apt install -y gcc make libaio-dev libblkid-dev
+
+
 How to test sanlock
 ===================
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -4,11 +4,13 @@
 # modify, copy, or redistribute it subject to the terms and conditions
 # of the GNU General Public License v.2.
 
+PYTHON := python$(PY_VERSION)
+
 all:
-	python2 setup.py build $(BUILDARGS)
+	$(PYTHON) setup.py build $(BUILDARGS)
 
 install:
-	python2 setup.py install --root=$(DESTDIR)
+	$(PYTHON) setup.py install --root=$(DESTDIR)
 
 clean:
 	rm -rf build

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -33,6 +33,7 @@
 /* Functions prototypes */
 static void __set_exception(int en, char *msg) __sets_exception;
 static int __parse_resource(PyObject *obj, struct sanlk_resource **res_ret) __neg_sets_exception;
+static void util_set_value_error(const char* format, PyObject* obj);
 
 /* Sanlock module */
 PyDoc_STRVAR(pydoc_sanlock, "\
@@ -109,8 +110,10 @@ __parse_resource(PyObject *obj, struct sanlk_resource **res_ret)
                 __set_exception(EINVAL, "Invalid resource offset");
                 goto exit_fail;
             }
-        } else if (PyString_Check(tuple)) {
-            p = PyString_AsString(tuple);
+        } else {
+            /* handle invalid non-tuple resource input */
+            util_set_value_error("invalid disk value: %s", tuple);
+            goto exit_fail;
         }
 
         if (p == NULL) {
@@ -182,6 +185,17 @@ add_align_flag(long align, uint32_t *flags)
 	return -1;
     }
     return 0;
+}
+
+static void
+util_set_value_error(const char* format, PyObject* obj)
+{
+    const char* str_rep = "";
+    PyObject* rep = PyObject_Repr(obj);
+    if (rep)
+        str_rep = PyString_AsString(rep);
+    PyErr_Format(PyExc_ValueError, format, str_rep);
+    Py_XDECREF(rep);
 }
 
 static PyObject *

--- a/sanlock.spec.in
+++ b/sanlock.spec.in
@@ -61,7 +61,8 @@ make -C wdmd \
         DESTDIR=$RPM_BUILD_ROOT
 make -C python \
         install LIBDIR=%{_libdir} \
-        DESTDIR=$RPM_BUILD_ROOT
+        DESTDIR=$RPM_BUILD_ROOT \
+        PY_VERSION=2.7 # TODO: fix PY_VERSION to 3.6 when 2020 will arrive
 make -C reset \
         install LIBDIR=%{_libdir} \
         DESTDIR=$RPM_BUILD_ROOT

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 Fixtures for sanlock testing.
 """
+from __future__ import absolute_import
 
 import pytest
 

--- a/tests/daemon_test.py
+++ b/tests/daemon_test.py
@@ -190,7 +190,7 @@ def test_lookup(tmpdir, sanlock_daemon):
     util.sanlock("client", "create", "-x", rindex, "-e", "res")
     lookup = util.sanlock("client", "lookup", "-x", rindex, "-e", "res")
 
-    assert lookup == "lookup done 0\nname res offset 3145728\n"
+    assert lookup == b"lookup done 0\nname res offset 3145728\n"
 
 
 def test_lookup_uninitialized(tmpdir, sanlock_daemon):
@@ -202,8 +202,8 @@ def test_lookup_uninitialized(tmpdir, sanlock_daemon):
         util.sanlock("client", "lookup", "-x", rindex, "-e", "res")
 
     assert e.value.returncode == 1
-    assert e.value.stdout == "lookup done -2\n"
-    assert e.value.stderr == ""
+    assert e.value.stdout == b"lookup done -2\n"
+    assert e.value.stderr == b""
 
 
 def test_lookup_missing(tmpdir, sanlock_daemon):
@@ -224,5 +224,5 @@ def test_lookup_missing(tmpdir, sanlock_daemon):
         util.sanlock("client", "lookup", "-x", rindex, "-e", "res")
 
     assert e.value.returncode == 1
-    assert e.value.stdout == "lookup done -2\n"
-    assert e.value.stderr == ""
+    assert e.value.stdout == b"lookup done -2\n"
+    assert e.value.stderr == b""

--- a/tests/daemon_test.py
+++ b/tests/daemon_test.py
@@ -1,6 +1,7 @@
 """
 Test sanlock client operations.
 """
+from __future__ import absolute_import
 
 import io
 import signal

--- a/tests/direct_test.py
+++ b/tests/direct_test.py
@@ -1,6 +1,7 @@
 """
 Test sanlock direct options.
 """
+from __future__ import absolute_import
 
 import io
 import struct

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -285,3 +285,12 @@ def test_write_resource_invalid_align_sector(
     with pytest.raises(ValueError):
         sanlock.write_resource(
             "ls_name", "res_name", disks, align=align, sector=sector)
+
+
+def test_write_resource_invalid_path(tmpdir, sanlock_daemon):
+    # Test parsing a resource which is not a list of tuples
+    disks = ["invalid resource tuple"]
+    with pytest.raises(ValueError) as e:
+        sanlock.write_resource("ls_name", "res_name", disks)
+    assert "invalid resource tuple" in repr(e.value)
+

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -41,7 +41,7 @@ def test_write_lockspace(tmpdir, sanlock_daemon, size, offset):
     sanlock.write_lockspace("name", path, offset=offset, iotimeout=1)
 
     ls = sanlock.read_lockspace(path, offset=offset)
-    assert ls == {"iotimeout": 1, "lockspace": "name"}
+    assert ls == {"iotimeout": 1, "lockspace": b"name"}
 
     # Test read and write with explicit alignment and sector size values.
     sanlock.write_lockspace(
@@ -82,8 +82,8 @@ def test_write_resource(tmpdir, sanlock_daemon, size, offset):
 
     res = sanlock.read_resource(path, offset=offset)
     assert res == {
-        "lockspace": "ls_name",
-        "resource": "res_name",
+        "lockspace": b"ls_name",
+        "resource": b"res_name",
         "version": 0
     }
 
@@ -211,8 +211,8 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
-        "lockspace": "ls_name",
-        "resource": "res_name",
+        "lockspace": b"ls_name",
+        "resource": b"res_name",
         "version": 0
     }
 
@@ -224,8 +224,8 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
-        "lockspace": "ls_name",
-        "resource": "res_name",
+        "lockspace": b"ls_name",
+        "resource": b"res_name",
         "version": 1
     }
 
@@ -245,8 +245,8 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
-        "lockspace": "ls_name",
-        "resource": "res_name",
+        "lockspace": b"ls_name",
+        "resource": b"res_name",
         "version": 1
     }
 

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -1,6 +1,7 @@
 """
 Test sanlock python binding with sanlock daemon.
 """
+from __future__ import absolute_import
 
 import errno
 import io

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,7 @@
 """
 Testing utilities
 """
+from __future__ import absolute_import
 
 import errno
 import io

--- a/tests/util.py
+++ b/tests/util.py
@@ -60,8 +60,8 @@ def wait_for_daemon(timeout):
             try:
                 s.connect(path)
                 return
-            except socket.error as e:
-                if e[0] not in (errno.ECONNREFUSED, errno.ENOENT):
+            except EnvironmentError as e:
+                if e.errno not in (errno.ECONNREFUSED, errno.ENOENT):
                     raise  # Unexpected error
             if time.time() > deadline:
                 raise TimeoutExpired

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,8 @@ whitelist_externals = make
 deps =
     pytest==4.0
 commands =
-    make BUILDARGS="--build-lib={envsitepackagesdir}"
+    py27: make PY_VERSION=2.7 BUILDARGS="--build-lib={envsitepackagesdir}"
+    py36: make PY_VERSION=3.6 BUILDARGS="--build-lib={envsitepackagesdir}"
     pytest {posargs}
 
 [pytest]


### PR DESCRIPTION
Resource API should only support (path, offset)tuple list

As stated in sanlock help, resource API only accepts [(path,offset),...] input form as resource argument.
In this patch a handle in resource parsing is added and a test for invalid input as well.

