### PR TITLE
File size constants

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -17,3 +17,9 @@ RINDEX_DISK_MAGIC = 0x01042018
 
 RINDEX_ENTRY_SIZE = 64
 RINDEX_ENTRIES_SECTORS = 2000
+
+# A few file/disk size constants.
+KiB = 1024      # 1 Kibibyte = 2^10 bytes = 1024 bytes
+MiB = 1024**2   # 1 Mebibyte = 2^20 bytes = 1,048,576 bytes = 1024 kibibytes
+GiB = 1024**3   # 1 Gibibyte = 2^30 bytes = 1,073,741,824 bytes = 1024 mebibytes
+TiB = 1024**4   # 1 Tebibyte = 2^40 bytes = 1,099,511,627,776 bytes = 1024 gibibytes

--- a/tests/daemon_test.py
+++ b/tests/daemon_test.py
@@ -44,7 +44,7 @@ def test_client_failure():
 
 def test_init_lockspace(tmpdir, sanlock_daemon):
     path = tmpdir.join("lockspace")
-    size = 1024**2
+    size = constants.MiB
     util.create_file(str(path), size)
 
     lockspace = "name:1:%s:0" % path
@@ -61,7 +61,7 @@ def test_init_lockspace(tmpdir, sanlock_daemon):
 
 def test_init_resource(tmpdir, sanlock_daemon):
     path = tmpdir.join("resources")
-    size = 1024**2
+    size = constants.MiB
     util.create_file(str(path), size)
 
     resource = "ls_name:res_name:%s:0" % path
@@ -78,7 +78,7 @@ def test_init_resource(tmpdir, sanlock_daemon):
 
 def test_format(tmpdir, sanlock_daemon):
     path = tmpdir.join("rindex")
-    size = 1024**2 * 3
+    size = constants.MiB * 3
     util.create_file(str(path), size)
 
     rindex = "ls_name:%s:1M" % path
@@ -86,18 +86,18 @@ def test_format(tmpdir, sanlock_daemon):
 
     with io.open(str(path), "rb") as f:
         # The first slot should contain the rindex header sector.
-        f.seek(1024**2)
+        f.seek(constants.MiB)
         magic, = struct.unpack("< I", f.read(4))
         assert magic == constants.RINDEX_DISK_MAGIC
 
         # The rindex entries starts at the second rindex slot sector. All
         # entries should be zeroed.
-        f.seek(1024**2 + 512)
+        f.seek(constants.MiB + 512)
         entries_size = 512 * constants.RINDEX_ENTRIES_SECTORS
         assert f.read(entries_size) == b"\0" * entries_size
 
         # The next slot should contain the internal lease.
-        f.seek(1024**2 * 2)
+        f.seek(constants.MiB * 2)
         magic, = struct.unpack("< I", f.read(4))
         assert magic == constants.PAXOS_DISK_MAGIC
 
@@ -107,7 +107,7 @@ def test_format(tmpdir, sanlock_daemon):
 def test_create(tmpdir, sanlock_daemon):
     path = tmpdir.join("rindex")
     # Slots: lockspace rindex master-lease user-lease-1
-    size = 1024**2 * 4
+    size = constants.MiB * 4
     util.create_file(str(path), size)
 
     # Note: using 1 second io timeout (-o 1) for quicker tests.
@@ -123,16 +123,16 @@ def test_create(tmpdir, sanlock_daemon):
     with io.open(str(path), "rb") as f:
         # New entry should be created at the first slot
         # The first rindex sector is used by the rindex header.
-        f.seek(1024**2 + 512)
+        f.seek(constants.MiB + 512)
         util.check_rindex_entry(f.read(constants.RINDEX_ENTRY_SIZE),
-                                b"res", 1024**2 * 3, 0)
+                                b"res", constants.MiB * 3, 0)
 
         # The rest of the entries should not be modified.
         rest = 512 * constants.RINDEX_ENTRIES_SECTORS - constants.RINDEX_ENTRY_SIZE
         assert f.read(rest) == b"\0" * rest
 
         # The next slot should contain the internal lease.
-        f.seek(1024**2 * 3)
+        f.seek(constants.MiB * 3)
         magic, = struct.unpack("< I", f.read(4))
         assert magic == constants.PAXOS_DISK_MAGIC
 
@@ -142,7 +142,7 @@ def test_create(tmpdir, sanlock_daemon):
 def test_delete(tmpdir, sanlock_daemon):
     path = tmpdir.join("rindex")
     # Slots: lockspace rindex master-lease user-lease-1
-    size = 1024**2 * 4
+    size = constants.MiB * 4
     util.create_file(str(path), size)
 
     # Note: using 1 second io timeout (-o 1) for quicker tests.
@@ -158,7 +158,7 @@ def test_delete(tmpdir, sanlock_daemon):
 
     with io.open(str(path), "rb") as f:
         # First entry should be cleared.
-        f.seek(1024**2 + 512)
+        f.seek(constants.MiB + 512)
         util.check_rindex_entry(f.read(constants.RINDEX_ENTRY_SIZE), b"", 0, 0)
 
         # Rest of entires should not be modified.
@@ -166,7 +166,7 @@ def test_delete(tmpdir, sanlock_daemon):
         assert f.read(rest) == b"\0" * rest
 
         # The next slot should contain a cleared lease.
-        f.seek(1024**2 * 3)
+        f.seek(constants.MiB * 3)
         magic, = struct.unpack("< I", f.read(4))
         assert magic == constants.PAXOS_DISK_CLEAR
 
@@ -176,7 +176,7 @@ def test_delete(tmpdir, sanlock_daemon):
 def test_lookup(tmpdir, sanlock_daemon):
     path = tmpdir.join("rindex")
     # Slots: lockspace rindex master-lease user-lease-1 ... user-lease-7
-    size = 1024**2 * 10
+    size = constants.MiB * 10
     util.create_file(str(path), size)
 
     # Note: using 1 second io timeout (-o 1) for quicker tests.
@@ -195,7 +195,7 @@ def test_lookup(tmpdir, sanlock_daemon):
 
 def test_lookup_uninitialized(tmpdir, sanlock_daemon):
     path = tmpdir.join("rindex")
-    util.create_file(str(path), 1024**2)
+    util.create_file(str(path), constants.MiB)
     rindex = "ls_name:%s:1M" % path
 
     with pytest.raises(util.CommandError) as e:
@@ -209,7 +209,7 @@ def test_lookup_uninitialized(tmpdir, sanlock_daemon):
 def test_lookup_missing(tmpdir, sanlock_daemon):
     path = tmpdir.join("rindex")
     # Slots: lockspace rindex master-lease user-lease-1 ... user-lease-7
-    size = 1024**2 * 10
+    size = constants.MiB * 10
     util.create_file(str(path), size)
 
     # Note: using 1 second io timeout (-o 1) for quicker tests.

--- a/tests/daemon_test.py
+++ b/tests/daemon_test.py
@@ -8,7 +8,7 @@ import struct
 
 import pytest
 
-from . constants import *
+from . import constants
 from . import util
 
 
@@ -52,7 +52,7 @@ def test_init_lockspace(tmpdir, sanlock_daemon):
 
     with io.open(str(path), "rb") as f:
         magic, = struct.unpack("< I", f.read(4))
-        assert magic == DELTA_DISK_MAGIC
+        assert magic == constants.DELTA_DISK_MAGIC
 
         # TODO: check more stuff here...
 
@@ -69,7 +69,7 @@ def test_init_resource(tmpdir, sanlock_daemon):
 
     with io.open(str(path), "rb") as f:
         magic, = struct.unpack("< I", f.read(4))
-        assert magic == PAXOS_DISK_MAGIC
+        assert magic == constants.PAXOS_DISK_MAGIC
 
         # TODO: check more stuff here...
 
@@ -88,18 +88,18 @@ def test_format(tmpdir, sanlock_daemon):
         # The first slot should contain the rindex header sector.
         f.seek(1024**2)
         magic, = struct.unpack("< I", f.read(4))
-        assert magic == RINDEX_DISK_MAGIC
+        assert magic == constants.RINDEX_DISK_MAGIC
 
         # The rindex entries starts at the second rindex slot sector. All
         # entries should be zeroed.
         f.seek(1024**2 + 512)
-        entries_size = 512 * RINDEX_ENTRIES_SECTORS
+        entries_size = 512 * constants.RINDEX_ENTRIES_SECTORS
         assert f.read(entries_size) == b"\0" * entries_size
 
         # The next slot should contain the internal lease.
         f.seek(1024**2 * 2)
         magic, = struct.unpack("< I", f.read(4))
-        assert magic == PAXOS_DISK_MAGIC
+        assert magic == constants.PAXOS_DISK_MAGIC
 
     util.check_guard(str(path), size)
 
@@ -124,17 +124,17 @@ def test_create(tmpdir, sanlock_daemon):
         # New entry should be created at the first slot
         # The first rindex sector is used by the rindex header.
         f.seek(1024**2 + 512)
-        util.check_rindex_entry(f.read(RINDEX_ENTRY_SIZE),
+        util.check_rindex_entry(f.read(constants.RINDEX_ENTRY_SIZE),
                                 b"res", 1024**2 * 3, 0)
 
         # The rest of the entries should not be modified.
-        rest = 512 * RINDEX_ENTRIES_SECTORS - RINDEX_ENTRY_SIZE
+        rest = 512 * constants.RINDEX_ENTRIES_SECTORS - constants.RINDEX_ENTRY_SIZE
         assert f.read(rest) == b"\0" * rest
 
         # The next slot should contain the internal lease.
         f.seek(1024**2 * 3)
         magic, = struct.unpack("< I", f.read(4))
-        assert magic == PAXOS_DISK_MAGIC
+        assert magic == constants.PAXOS_DISK_MAGIC
 
     util.check_guard(str(path), size)
 
@@ -159,16 +159,16 @@ def test_delete(tmpdir, sanlock_daemon):
     with io.open(str(path), "rb") as f:
         # First entry should be cleared.
         f.seek(1024**2 + 512)
-        util.check_rindex_entry(f.read(RINDEX_ENTRY_SIZE), b"", 0, 0)
+        util.check_rindex_entry(f.read(constants.RINDEX_ENTRY_SIZE), b"", 0, 0)
 
         # Rest of entires should not be modified.
-        rest = 512 * RINDEX_ENTRIES_SECTORS - RINDEX_ENTRY_SIZE
+        rest = 512 * constants.RINDEX_ENTRIES_SECTORS - constants.RINDEX_ENTRY_SIZE
         assert f.read(rest) == b"\0" * rest
 
         # The next slot should contain a cleared lease.
         f.seek(1024**2 * 3)
         magic, = struct.unpack("< I", f.read(4))
-        assert magic == PAXOS_DISK_CLEAR
+        assert magic == constants.PAXOS_DISK_CLEAR
 
     util.check_guard(str(path), size)
 

--- a/tests/direct_test.py
+++ b/tests/direct_test.py
@@ -11,7 +11,7 @@ from . import util
 
 def test_init_lockspace(tmpdir):
     path = tmpdir.join("lockspace")
-    size = 1024**2
+    size = constants.MiB
     util.create_file(str(path), size)
 
     lockspace = "name:1:%s:0" % path
@@ -28,7 +28,7 @@ def test_init_lockspace(tmpdir):
 
 def test_init_resource(tmpdir, sanlock_daemon):
     path = tmpdir.join("resources")
-    size = 1024**2
+    size = constants.MiB
     util.create_file(str(path), size)
 
     resource = "ls_name:res_name:%s:0" % path

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -18,12 +18,12 @@ from . import util
 # large enough to test large offsets, and less likely to fail on developer
 # machine or CI slave.
 # See https://access.redhat.com/articles/rhel-limits
-LARGE_FILE_SIZE = 1024**4
+LARGE_FILE_SIZE = constants.TiB
 
-LOCKSPACE_SIZE = 1024**2
-MIN_RES_SIZE = 1024**2
+LOCKSPACE_SIZE = constants.MiB
+MIN_RES_SIZE = constants.MiB
 
-ALIGNMENT_1M = 1024**2
+ALIGNMENT_1M = constants.MiB
 SECTOR_SIZE_512 = 512
 
 
@@ -147,7 +147,7 @@ def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset):
 
 def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):
     path = str(tmpdir.join("ls_name"))
-    util.create_file(path, 1024**2)
+    util.create_file(path, constants.MiB)
 
     sanlock.write_lockspace("ls_name", path, iotimeout=1)
     acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
@@ -256,7 +256,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
 
 @pytest.mark.parametrize("align, sector", [
     # Invalid alignment
-    (1024, sanlock.SECTOR_SIZE[0]),
+    (constants.KiB, sanlock.SECTOR_SIZE[0]),
     # Invalid sector size
     (sanlock.ALIGN_SIZE[0], 8192),
 ])
@@ -271,7 +271,7 @@ def test_write_lockspace_invalid_align_sector(
 
 @pytest.mark.parametrize("align, sector", [
     # Invalid alignment
-    (1024, sanlock.SECTOR_SIZE[0]),
+    (constants.KiB, sanlock.SECTOR_SIZE[0]),
     # Invalid sector size
     (sanlock.ALIGN_SIZE[0], 8192),
 ])


### PR DESCRIPTION
1) Adding constants for Kibibyte, Mebibyte, Gibibyte & Tebibyte and using them everywhere in tests.
2) Removing the "import *" style of "constants.py" import in "tests/daemon_test.py".