### PR TITLE
Python3 porting

### DIFF
--- a/README.dev
+++ b/README.dev
@@ -1,3 +1,15 @@
+Prerequisites
+=============
+
+For Fedora/CentOS install the following packages:
+
+   $ sudo yum install -y gcc make libaio-devel libblkid-devel
+
+For Ubuntu/Debian install the following packages:
+
+   $ sudo apt install -y gcc make libaio-dev libblkid-dev
+
+
 How to test sanlock
 ===================
 

--- a/python/Makefile
+++ b/python/Makefile
@@ -4,11 +4,13 @@
 # modify, copy, or redistribute it subject to the terms and conditions
 # of the GNU General Public License v.2.
 
+PYTHON := python$(PY_VERSION)
+
 all:
-	python2 setup.py build $(BUILDARGS)
+	$(PYTHON) setup.py build $(BUILDARGS)
 
 install:
-	python2 setup.py install --root=$(DESTDIR)
+	$(PYTHON) setup.py install --root=$(DESTDIR)
 
 clean:
 	rm -rf build

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -46,6 +46,20 @@ of the GNU General Public License v2 or (at your option) any later version.");
 /* Sanlock exception */
 static PyObject *py_exception;
 
+/*
+    Python 2 forward compatibility functions with Python 3
+    TODO: Once Python 2 will reach EOL at 2020 discrad this section
+*/
+#if PY_MAJOR_VERSION == 2
+
+static const char*
+PyUnicode_AsUTF8(PyObject* obj)
+{
+    return PyString_AsString(obj);
+}
+
+#endif
+
 static void
 __set_exception(int en, char *msg)
 {
@@ -91,8 +105,9 @@ __parse_resource(PyObject *obj, struct sanlk_resource **res_ret)
     res->num_disks = num_disks;
 
     for (i = 0; i < num_disks; i++) {
-        char *p = NULL;
+        const char *p = NULL;
         PyObject *tuple, *path = NULL, *offset = NULL;
+        int offset_is_int = 0;
 
         tuple = PyList_GetItem(obj, i);
 
@@ -105,9 +120,15 @@ __parse_resource(PyObject *obj, struct sanlk_resource **res_ret)
             path = PyTuple_GetItem(tuple, 0);
             offset = PyTuple_GetItem(tuple, 1);
 
-            p = PyString_AsString(path);
+            p = PyUnicode_AsUTF8(path);
 
-            if (!PyInt_Check(offset)) {
+#if PY_MAJOR_VERSION == 2
+            offset_is_int = PyInt_Check(offset) || PyLong_Check(offset);
+#else
+            offset_is_int = PyLong_Check(offset);
+#endif
+
+            if (!offset_is_int) {
                 __set_exception(EINVAL, "Invalid resource offset");
                 goto exit_fail;
             }
@@ -123,7 +144,7 @@ __parse_resource(PyObject *obj, struct sanlk_resource **res_ret)
         if (offset == NULL) {
             res->disks[i].offset = 0;
         } else {
-            res->disks[i].offset = PyInt_AsLong(offset);
+            res->disks[i].offset = PyLong_AsLong(offset);
         }
     }
 
@@ -199,7 +220,7 @@ __hosts_to_list(struct sanlk_host *hss, int hss_count)
             goto exit_fail;
 
         /* fill the dictionary information: host_id */
-        if ((ls_value = PyInt_FromLong(hss[i].host_id)) == NULL)
+        if ((ls_value = PyLong_FromLong(hss[i].host_id)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "host_id", ls_value);
         Py_DECREF(ls_value);
@@ -207,7 +228,7 @@ __hosts_to_list(struct sanlk_host *hss, int hss_count)
             goto exit_fail;
 
         /* fill the dictionary information: generation */
-        if ((ls_value = PyInt_FromLong(hss[i].generation)) == NULL)
+        if ((ls_value = PyLong_FromLong(hss[i].generation)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "generation", ls_value);
         Py_DECREF(ls_value);
@@ -215,7 +236,7 @@ __hosts_to_list(struct sanlk_host *hss, int hss_count)
             goto exit_fail;
 
         /* fill the dictionary information: timestamp */
-        if ((ls_value = PyInt_FromLong(hss[i].timestamp)) == NULL)
+        if ((ls_value = PyLong_FromLong(hss[i].timestamp)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "timestamp", ls_value);
         Py_DECREF(ls_value);
@@ -223,7 +244,7 @@ __hosts_to_list(struct sanlk_host *hss, int hss_count)
             goto exit_fail;
 
         /* fill the dictionary information: io_timeout */
-        if ((ls_value = PyInt_FromLong(hss[i].io_timeout)) == NULL)
+        if ((ls_value = PyLong_FromLong(hss[i].io_timeout)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "io_timeout", ls_value);
         Py_DECREF(ls_value);
@@ -231,7 +252,7 @@ __hosts_to_list(struct sanlk_host *hss, int hss_count)
             goto exit_fail;
 
         /* fill the dictionary information: flags */
-        if ((ls_value = PyInt_FromLong(hss[i].flags)) == NULL)
+        if ((ls_value = PyLong_FromLong(hss[i].flags)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "flags", ls_value);
         Py_DECREF(ls_value);
@@ -274,7 +295,7 @@ py_register(PyObject *self __unused, PyObject *args)
         return NULL;
     }
 
-    return PyInt_FromLong(sanlockfd);
+    return PyLong_FromLong(sanlockfd);
 }
 
 /* get_alignment */
@@ -307,7 +328,7 @@ py_get_alignment(PyObject *self __unused, PyObject *args)
         return NULL;
     }
 
-    return PyInt_FromLong(rv);
+    return PyLong_FromLong(rv);
 }
 
 /* init_lockspace */
@@ -514,7 +535,7 @@ py_read_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
         goto exit_fail;
 
     /* fill the dictionary information: lockspace */
-    if ((ls_entry = PyString_FromString(ls.name)) == NULL)
+    if ((ls_entry = PyBytes_FromString(ls.name)) == NULL)
         goto exit_fail;
     rv = PyDict_SetItemString(ls_info, "lockspace", ls_entry);
     Py_DECREF(ls_entry);
@@ -522,7 +543,7 @@ py_read_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
         goto exit_fail;
 
     /* fill the dictionary information: iotimeout */
-    if ((ls_entry = PyInt_FromLong(io_timeout)) == NULL)
+    if ((ls_entry = PyLong_FromLong(io_timeout)) == NULL)
         goto exit_fail;
     rv = PyDict_SetItemString(ls_info, "iotimeout", ls_entry);
     Py_DECREF(ls_entry);
@@ -600,7 +621,7 @@ py_read_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
         goto exit_fail;
 
     /* fill the dictionary information: lockspace */
-    if ((rs_entry = PyString_FromString(rs->lockspace_name)) == NULL)
+    if ((rs_entry = PyBytes_FromString(rs->lockspace_name)) == NULL)
         goto exit_fail;
     rv = PyDict_SetItemString(rs_info, "lockspace", rs_entry);
     Py_DECREF(rs_entry);
@@ -608,7 +629,7 @@ py_read_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
         goto exit_fail;
 
     /* fill the dictionary information: resource */
-    if ((rs_entry = PyString_FromString(rs->name)) == NULL)
+    if ((rs_entry = PyBytes_FromString(rs->name)) == NULL)
         goto exit_fail;
     rv = PyDict_SetItemString(rs_info, "resource", rs_entry);
     Py_DECREF(rs_entry);
@@ -900,7 +921,7 @@ py_get_lockspaces(PyObject *self __unused, PyObject *args, PyObject *keywds)
             goto exit_fail;
 
         /* fill the dictionary information: lockspace */
-        if ((ls_value = PyString_FromString(lss[i].name)) == NULL)
+        if ((ls_value = PyBytes_FromString(lss[i].name)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "lockspace", ls_value);
         Py_DECREF(ls_value);
@@ -908,7 +929,7 @@ py_get_lockspaces(PyObject *self __unused, PyObject *args, PyObject *keywds)
             goto exit_fail;
 
         /* fill the dictionary information: host_id */
-        if ((ls_value = PyInt_FromLong(lss[i].host_id)) == NULL)
+        if ((ls_value = PyLong_FromLong(lss[i].host_id)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "host_id", ls_value);
         Py_DECREF(ls_value);
@@ -916,7 +937,7 @@ py_get_lockspaces(PyObject *self __unused, PyObject *args, PyObject *keywds)
             goto exit_fail;
 
         /* fill the dictionary information: path */
-        if ((ls_value = PyString_FromString(lss[i].host_id_disk.path)) == NULL)
+        if ((ls_value = PyUnicode_FromString(lss[i].host_id_disk.path)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "path", ls_value);
         Py_DECREF(ls_value);
@@ -924,7 +945,7 @@ py_get_lockspaces(PyObject *self __unused, PyObject *args, PyObject *keywds)
             goto exit_fail;
 
         /* fill the dictionary information: offset */
-        if ((ls_value = PyInt_FromLong(lss[i].host_id_disk.offset)) == NULL)
+        if ((ls_value = PyLong_FromLong(lss[i].host_id_disk.offset)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "offset", ls_value);
         Py_DECREF(ls_value);
@@ -932,7 +953,7 @@ py_get_lockspaces(PyObject *self __unused, PyObject *args, PyObject *keywds)
             goto exit_fail;
 
         /* fill the dictionary information: flags */
-        if ((ls_value = PyInt_FromLong(lss[i].flags)) == NULL)
+        if ((ls_value = PyLong_FromLong(lss[i].flags)) == NULL)
             goto exit_fail;
         rv = PyDict_SetItemString(ls_entry, "flags", ls_value);
         Py_DECREF(ls_value);
@@ -1054,7 +1075,7 @@ py_acquire(PyObject *self __unused, PyObject *args, PyObject *keywds)
     /* prepare the resource version */
     if (version != Py_None) {
         res->flags |= SANLK_RES_LVER;
-        res->lver = PyInt_AsUnsignedLongMask(version);
+        res->lver = PyLong_AsUnsignedLongMask(version);
         if (res->lver == -1) {
             __set_exception(EINVAL, "Unable to convert the version value");
             goto exit_fail;
@@ -1170,7 +1191,7 @@ py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
         flags = SANLK_REQUEST_NEXT_LVER;
     } else {
         res->flags |= SANLK_RES_LVER;
-        res->lver = PyInt_AsUnsignedLongMask(version);
+        res->lver = PyLong_AsUnsignedLongMask(version);
         if (res->lver == -1) {
             __set_exception(EINVAL, "Unable to convert the version value");
             goto exit_fail;
@@ -1285,7 +1306,7 @@ py_killpath(PyObject *self __unused, PyObject *args, PyObject *keywds)
         size_t arg_len;
 
         item = PyList_GetItem(argslist, i);
-        p = PyString_AsString(item);
+        p = PyUnicode_AsUTF8(item);
 
         if (p == NULL) {
             __set_exception(EINVAL, "Killpath argument not a string");

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -1744,6 +1744,36 @@ exit_fail:
 	return -1;
 }
 
+#if PY_MAJOR_VERSION >= 3 /* Python 3 module init */
+
+static struct PyModuleDef moduledef = {
+        PyModuleDef_HEAD_INIT,
+        MODULE_NAME,
+        pydoc_sanlock,
+        -1,
+        sanlock_methods,
+};
+
+PyMODINIT_FUNC
+PyInit_sanlock(void)
+{
+    PyObject *m = NULL;
+
+    m = PyModule_Create(&moduledef);
+
+    if (m == NULL)
+        return NULL;
+
+    if (util_module_init(m)) {
+        Py_DECREF(m);
+        return NULL;
+    }
+
+    return m;
+}
+
+#else /* Python 2 module init */
+
 PyMODINIT_FUNC
 initsanlock(void)
 {
@@ -1758,3 +1788,5 @@ initsanlock(void)
     if (util_module_init(m))
         Py_DECREF(m);
 }
+
+#endif

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -388,8 +388,7 @@ static PyObject *
 py_init_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, use_aio = 1;
-    const char *lockspace;
-    PyObject *path = NULL;
+    PyObject *lockspace = NULL, *path = NULL;
     struct sanlk_lockspace ls;
 
     static char *kwlist[] = {"lockspace", "path", "offset",
@@ -399,7 +398,7 @@ py_init_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ss|kiii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "Ss|kiii", kwlist,
         &lockspace, PyUnicode_FSConverter, &path, &ls.host_id_disk.offset, &max_hosts,
         &num_hosts, &use_aio)) {
         return NULL;
@@ -409,7 +408,7 @@ py_init_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
         return NULL;
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, PyBytes_AsString(path), SANLK_PATH_LEN - 1);
     Py_DECREF(path);
 
@@ -438,15 +437,15 @@ static PyObject *
 py_init_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, use_aio = 1;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks;
+    PyObject *disks, *lockspace = NULL;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "max_hosts",
                                 "num_hosts", "use_aio", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|iii",
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iii",
         kwlist, &lockspace, &resource, &PyList_Type, &disks, &max_hosts,
         &num_hosts, &use_aio)) {
         return NULL;
@@ -458,7 +457,7 @@ py_init_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* init sanlock resource (gil disabled) */
@@ -493,8 +492,7 @@ py_write_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     int rv, max_hosts = 0, sector = SECTOR_SIZE_512;
     long align = ALIGNMENT_1M;
     uint32_t io_timeout = 0;
-    const char *lockspace;
-    PyObject *path = NULL;
+    PyObject *lockspace = NULL, *path = NULL;
     struct sanlk_lockspace ls;
 
     static char *kwlist[] = {"lockspace", "path", "offset", "max_hosts",
@@ -504,7 +502,7 @@ py_write_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "sO&|kiIli", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SO&|kiIli", kwlist,
         &lockspace, PyUnicode_FSConverter, &path, &ls.host_id_disk.offset, &max_hosts,
         &io_timeout, &align, &sector)) {
         return NULL;
@@ -514,7 +512,7 @@ py_write_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
         return NULL;
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, PyBytes_AsString(path), SANLK_PATH_LEN - 1);
     Py_DECREF(path);
 
@@ -735,16 +733,16 @@ py_write_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, clear = 0, sector = SECTOR_SIZE_512;
     long align = ALIGNMENT_1M;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *rs;
-    PyObject *disks;
+    PyObject *lockspace = NULL, *disks;
     uint32_t flags = 0;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "max_hosts",
                                 "num_hosts", "clear", "align", "sector", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|iiili",
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iiili",
         kwlist, &lockspace, &resource, &PyList_Type, &disks, &max_hosts,
         &num_hosts, &clear, &align, &sector)) {
         return NULL;
@@ -756,7 +754,7 @@ py_write_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(rs->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(rs->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(rs->name, resource, SANLK_NAME_LEN);
 
     /* set alignment/sector flags */
@@ -801,8 +799,7 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, async = 0, flags = 0;
     uint32_t iotimeout = 0;
-    const char *lockspace;
-    PyObject *path = NULL;
+    PyObject *lockspace = NULL, *path = NULL;
     struct sanlk_lockspace ls;
 
     static char *kwlist[] = {"lockspace", "host_id", "path", "offset",
@@ -812,7 +809,7 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "skO&|kIi", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SkO&|kIi", kwlist,
         &lockspace, &ls.host_id, PyUnicode_FSConverter, &path, &ls.host_id_disk.offset,
         &iotimeout, &async)) {
         return NULL;
@@ -827,7 +824,7 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, PyBytes_AsString(path), SANLK_PATH_LEN - 1);
     Py_DECREF(path);
 
@@ -857,8 +854,7 @@ static PyObject *
 py_inq_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, waitrs = 0, flags = 0;
-    const char *lockspace;
-    PyObject *path = NULL;
+    PyObject *lockspace = NULL, *path = NULL;
     struct sanlk_lockspace ls;
 
     static char *kwlist[] = {"lockspace", "host_id", "path", "offset",
@@ -868,7 +864,7 @@ py_inq_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "skO&|ki", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SkO&|ki", kwlist,
         &lockspace, &ls.host_id, PyUnicode_FSConverter, &path, &ls.host_id_disk.offset,
         &waitrs)) {
         return NULL;
@@ -883,7 +879,7 @@ py_inq_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, PyBytes_AsString(path), SANLK_PATH_LEN - 1);
     Py_DECREF(path);
 
@@ -918,8 +914,7 @@ static PyObject *
 py_rem_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, async = 0, unused = 0, flags = 0;
-    const char *lockspace;
-    PyObject *path = NULL;
+    PyObject *lockspace = NULL, *path = NULL;
     struct sanlk_lockspace ls;
 
     static char *kwlist[] = {"lockspace", "host_id", "path", "offset",
@@ -929,7 +924,7 @@ py_rem_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "skO&|kii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SkO&|kii", kwlist,
         &lockspace, &ls.host_id, PyUnicode_FSConverter, &path, &ls.host_id_disk.offset,
         &async, &unused)) {
         return NULL;
@@ -939,7 +934,7 @@ py_rem_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
         return NULL;
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, PyBytes_AsString(path), SANLK_PATH_LEN - 1);
     Py_DECREF(path);
 
@@ -1074,21 +1069,20 @@ py_get_hosts(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, hss_count = 0;
     uint64_t host_id = 0;
-    const char *lockspace = NULL;
     struct sanlk_host *hss = NULL;
-    PyObject *ls_list = NULL;
+    PyObject *lockspace = NULL, *ls_list = NULL;
 
     static char *kwlist[] = {"lockspace", "host_id", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s|k", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "S|k", kwlist,
         &lockspace, &host_id)) {
         return NULL;
     }
 
     /* get all the lockspaces (gil disabled) */
     Py_BEGIN_ALLOW_THREADS
-    rv = sanlock_get_hosts(lockspace, host_id, &hss, &hss_count, 0);
+    rv = sanlock_get_hosts(PyBytes_AsString(lockspace), host_id, &hss, &hss_count, 0);
     Py_END_ALLOW_THREADS
 
     if (rv < 0) {
@@ -1117,15 +1111,15 @@ static PyObject *
 py_acquire(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, sanlockfd = -1, pid = -1, shared = 0;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *version = Py_None;
+    PyObject *disks, *lockspace = NULL, *version = Py_None;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "slkfd",
                                 "pid", "shared", "version", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|iiiO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iiiO", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &sanlockfd, &pid,
         &shared, &version)) {
         return NULL;
@@ -1143,7 +1137,7 @@ py_acquire(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* prepare sanlock flags */
@@ -1189,15 +1183,15 @@ static PyObject *
 py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, sanlockfd = -1, pid = -1;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks;
+    PyObject *disks, *lockspace = NULL;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "slkfd",
                                 "pid", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|ii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|ii", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &sanlockfd, &pid)) {
         return NULL;
     }
@@ -1208,7 +1202,7 @@ py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* release sanlock resource (gil disabled) */
@@ -1243,15 +1237,15 @@ static PyObject *
 py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, action = SANLK_REQ_GRACEFUL, flags = 0;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *version = Py_None;
+    PyObject *disks, *lockspace = NULL, *version = Py_None;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "action",
                                 "version", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|iO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iO", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &action, &version)) {
         return NULL;
     }
@@ -1262,7 +1256,7 @@ py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* prepare the resource version */
@@ -1307,15 +1301,15 @@ static PyObject *
 py_read_resource_owners(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, hss_count = 0;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res = NULL;
     struct sanlk_host *hss = NULL;
-    PyObject *disks, *ls_list = NULL;
+    PyObject *disks, *lockspace = NULL, *ls_list = NULL;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!", kwlist,
         &lockspace, &resource, &PyList_Type, &disks)) {
         return NULL;
     }
@@ -1326,7 +1320,7 @@ py_read_resource_owners(PyObject *self __unused, PyObject *args, PyObject *keywd
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* read resource owners (gil disabled) */

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -111,8 +111,6 @@ __parse_resource(PyObject *obj, struct sanlk_resource **res_ret)
                 __set_exception(EINVAL, "Invalid resource offset");
                 goto exit_fail;
             }
-        } else if (PyString_Check(tuple)) {
-            p = PyString_AsString(tuple);
         }
 
         if (p == NULL) {

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -437,15 +437,14 @@ static PyObject *
 py_init_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, use_aio = 1;
-    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *lockspace = NULL;
+    PyObject *disks, *lockspace = NULL, *resource = NULL;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "max_hosts",
                                 "num_hosts", "use_aio", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iii",
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|iii",
         kwlist, &lockspace, &resource, &PyList_Type, &disks, &max_hosts,
         &num_hosts, &use_aio)) {
         return NULL;
@@ -458,7 +457,7 @@ py_init_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* init sanlock resource (gil disabled) */
     Py_BEGIN_ALLOW_THREADS
@@ -733,16 +732,15 @@ py_write_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, clear = 0, sector = SECTOR_SIZE_512;
     long align = ALIGNMENT_1M;
-    const char *resource;
     struct sanlk_resource *rs;
-    PyObject *lockspace = NULL, *disks;
+    PyObject *lockspace = NULL, *resource = NULL, *disks;
     uint32_t flags = 0;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "max_hosts",
                                 "num_hosts", "clear", "align", "sector", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iiili",
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|iiili",
         kwlist, &lockspace, &resource, &PyList_Type, &disks, &max_hosts,
         &num_hosts, &clear, &align, &sector)) {
         return NULL;
@@ -755,7 +753,7 @@ py_write_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(rs->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(rs->name, resource, SANLK_NAME_LEN);
+    strncpy(rs->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* set alignment/sector flags */
     if (add_align_flag(align, &rs->flags) == -1)
@@ -1111,15 +1109,14 @@ static PyObject *
 py_acquire(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, sanlockfd = -1, pid = -1, shared = 0;
-    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *lockspace = NULL, *version = Py_None;
+    PyObject *disks, *lockspace = NULL, *resource= NULL, *version = Py_None;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "slkfd",
                                 "pid", "shared", "version", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iiiO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|iiiO", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &sanlockfd, &pid,
         &shared, &version)) {
         return NULL;
@@ -1138,7 +1135,7 @@ py_acquire(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* prepare sanlock flags */
     if (shared) {
@@ -1183,15 +1180,14 @@ static PyObject *
 py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, sanlockfd = -1, pid = -1;
-    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *lockspace = NULL;
+    PyObject *disks, *lockspace = NULL, *resource = NULL;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "slkfd",
                                 "pid", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|ii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|ii", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &sanlockfd, &pid)) {
         return NULL;
     }
@@ -1203,7 +1199,7 @@ py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* release sanlock resource (gil disabled) */
     Py_BEGIN_ALLOW_THREADS
@@ -1237,15 +1233,14 @@ static PyObject *
 py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, action = SANLK_REQ_GRACEFUL, flags = 0;
-    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *lockspace = NULL, *version = Py_None;
+    PyObject *disks, *lockspace = NULL, *resource = NULL, *version = Py_None;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "action",
                                 "version", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|iO", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &action, &version)) {
         return NULL;
     }
@@ -1257,7 +1252,7 @@ py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* prepare the resource version */
     if (version == Py_None) {
@@ -1301,15 +1296,14 @@ static PyObject *
 py_read_resource_owners(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, hss_count = 0;
-    const char *resource;
     struct sanlk_resource *res = NULL;
     struct sanlk_host *hss = NULL;
-    PyObject *disks, *lockspace = NULL, *ls_list = NULL;
+    PyObject *disks, *lockspace = NULL, *ls_list = NULL, *resource = NULL;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!", kwlist,
         &lockspace, &resource, &PyList_Type, &disks)) {
         return NULL;
     }
@@ -1321,7 +1315,7 @@ py_read_resource_owners(PyObject *self __unused, PyObject *args, PyObject *keywd
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* read resource owners (gil disabled) */
     Py_BEGIN_ALLOW_THREADS

--- a/sanlock.spec.in
+++ b/sanlock.spec.in
@@ -61,7 +61,8 @@ make -C wdmd \
         DESTDIR=$RPM_BUILD_ROOT
 make -C python \
         install LIBDIR=%{_libdir} \
-        DESTDIR=$RPM_BUILD_ROOT
+        DESTDIR=$RPM_BUILD_ROOT \
+        PY_VERSION=2.7 # TODO: fix PY_VERSION to 3.6 when 2020 will arrive
 make -C reset \
         install LIBDIR=%{_libdir} \
         DESTDIR=$RPM_BUILD_ROOT

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """
 Fixtures for sanlock testing.
 """
+from __future__ import absolute_import
 
 import pytest
 

--- a/tests/daemon_test.py
+++ b/tests/daemon_test.py
@@ -190,7 +190,7 @@ def test_lookup(tmpdir, sanlock_daemon):
     util.sanlock("client", "create", "-x", rindex, "-e", "res")
     lookup = util.sanlock("client", "lookup", "-x", rindex, "-e", "res")
 
-    assert lookup == "lookup done 0\nname res offset 3145728\n"
+    assert lookup == b"lookup done 0\nname res offset 3145728\n"
 
 
 def test_lookup_uninitialized(tmpdir, sanlock_daemon):
@@ -202,8 +202,8 @@ def test_lookup_uninitialized(tmpdir, sanlock_daemon):
         util.sanlock("client", "lookup", "-x", rindex, "-e", "res")
 
     assert e.value.returncode == 1
-    assert e.value.stdout == "lookup done -2\n"
-    assert e.value.stderr == ""
+    assert e.value.stdout == b"lookup done -2\n"
+    assert e.value.stderr == b""
 
 
 def test_lookup_missing(tmpdir, sanlock_daemon):
@@ -224,5 +224,5 @@ def test_lookup_missing(tmpdir, sanlock_daemon):
         util.sanlock("client", "lookup", "-x", rindex, "-e", "res")
 
     assert e.value.returncode == 1
-    assert e.value.stdout == "lookup done -2\n"
-    assert e.value.stderr == ""
+    assert e.value.stdout == b"lookup done -2\n"
+    assert e.value.stderr == b""

--- a/tests/daemon_test.py
+++ b/tests/daemon_test.py
@@ -1,6 +1,7 @@
 """
 Test sanlock client operations.
 """
+from __future__ import absolute_import
 
 import io
 import signal

--- a/tests/direct_test.py
+++ b/tests/direct_test.py
@@ -1,6 +1,7 @@
 """
 Test sanlock direct options.
 """
+from __future__ import absolute_import
 
 import io
 import struct

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -28,6 +28,9 @@ MIN_RES_SIZE = 1024**2
 ALIGNMENT_1M = 1024**2
 SECTOR_SIZE_512 = 512
 
+#keep python 3 long compatibility with python 2
+if sys.version_info[0] >= 3:
+    long = int
 
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
@@ -76,9 +79,9 @@ def test_write_lockspace(tmpdir, sanlock_daemon, size, offset, filename, encodin
 
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
-    (MIN_RES_SIZE, 0),
+    (MIN_RES_SIZE, long(0)),
     # Large offset.
-    (LARGE_FILE_SIZE, LARGE_FILE_SIZE - MIN_RES_SIZE),
+    (LARGE_FILE_SIZE, long(LARGE_FILE_SIZE - MIN_RES_SIZE)),
 ])
 @pytest.mark.parametrize("filename,encoding", [
     (u"ascii", None),
@@ -131,7 +134,7 @@ def test_write_resource(tmpdir, sanlock_daemon, size, offset, filename, encoding
     # Smallest offset.
     (MIN_RES_SIZE, 0),
     # Large offset.
-    (LARGE_FILE_SIZE, LARGE_FILE_SIZE - MIN_RES_SIZE),
+    (LARGE_FILE_SIZE, long(LARGE_FILE_SIZE - MIN_RES_SIZE)),
 ])
 @pytest.mark.parametrize("filename,encoding", [
     (u"ascii", None),
@@ -203,9 +206,9 @@ def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):
 
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
-    (MIN_RES_SIZE, 0),
+    (MIN_RES_SIZE, long(0)),
     # Large offset.
-    (LARGE_FILE_SIZE, LARGE_FILE_SIZE - MIN_RES_SIZE),
+    (LARGE_FILE_SIZE, long(LARGE_FILE_SIZE) - MIN_RES_SIZE),
 ])
 def test_acquire_release_resource_size_offset(tmpdir, sanlock_daemon, size, offset):
     internal_test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset)

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -41,7 +41,7 @@ def test_write_lockspace(tmpdir, sanlock_daemon, size, offset):
     sanlock.write_lockspace("name", path, offset=offset, iotimeout=1)
 
     ls = sanlock.read_lockspace(path, offset=offset)
-    assert ls == {"iotimeout": 1, "lockspace": "name"}
+    assert ls == {"iotimeout": 1, "lockspace": b"name"}
 
     # Test read and write with explicit alignment and sector size values.
     sanlock.write_lockspace(
@@ -82,8 +82,8 @@ def test_write_resource(tmpdir, sanlock_daemon, size, offset):
 
     res = sanlock.read_resource(path, offset=offset)
     assert res == {
-        "lockspace": "ls_name",
-        "resource": "res_name",
+        "lockspace": b"ls_name",
+        "resource": b"res_name",
         "version": 0
     }
 
@@ -211,8 +211,8 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
-        "lockspace": "ls_name",
-        "resource": "res_name",
+        "lockspace": b"ls_name",
+        "resource": b"res_name",
         "version": 0
     }
 
@@ -224,8 +224,8 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
-        "lockspace": "ls_name",
-        "resource": "res_name",
+        "lockspace": b"ls_name",
+        "resource": b"res_name",
         "version": 1
     }
 
@@ -245,8 +245,8 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
-        "lockspace": "ls_name",
-        "resource": "res_name",
+        "lockspace": b"ls_name",
+        "resource": b"res_name",
         "version": 1
     }
 

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -34,8 +34,14 @@ SECTOR_SIZE_512 = 512
     # Large offset.
     (LARGE_FILE_SIZE, LARGE_FILE_SIZE - LOCKSPACE_SIZE),
 ])
-def test_write_lockspace(tmpdir, sanlock_daemon, size, offset):
-    path = str(tmpdir.join("lockspace"))
+@pytest.mark.parametrize("filename,encoding", [
+    (u"ascii", None),
+    (u"\u05d0", None),
+    ("ascii", None),
+    (u"\u05d0", "utf-8"),
+])
+def test_write_lockspace(tmpdir, sanlock_daemon, size, offset, filename, encoding):
+    path = util.generate_path(tmpdir, filename, encoding)
     util.create_file(path, size)
 
     # Test read and write with default alignment and sector size values.
@@ -73,8 +79,14 @@ def test_write_lockspace(tmpdir, sanlock_daemon, size, offset):
     # Large offset.
     (LARGE_FILE_SIZE, LARGE_FILE_SIZE - MIN_RES_SIZE),
 ])
-def test_write_resource(tmpdir, sanlock_daemon, size, offset):
-    path = str(tmpdir.join("resources"))
+@pytest.mark.parametrize("filename,encoding", [
+    (u"ascii", None),
+    (u"\u05d0", None),
+    ("ascii", None),
+    (u"\u05d0", "utf-8"),
+])
+def test_write_resource(tmpdir, sanlock_daemon, size, offset, filename, encoding):
+    path = util.generate_path(tmpdir, filename, encoding)
     util.create_file(path, size)
     disks = [(path, offset)]
 
@@ -120,8 +132,14 @@ def test_write_resource(tmpdir, sanlock_daemon, size, offset):
     # Large offset.
     (LARGE_FILE_SIZE, LARGE_FILE_SIZE - MIN_RES_SIZE),
 ])
-def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset):
-    path = str(tmpdir.join("ls_name"))
+@pytest.mark.parametrize("filename,encoding", [
+    (u"ascii", None),
+    (u"\u05d0", None),
+    ("ascii", None),
+    (u"\u05d0", "utf-8"),
+])
+def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset, filename, encoding):
+    path = util.generate_path(tmpdir, filename, encoding)
     util.create_file(path, size)
 
     sanlock.write_lockspace("ls_name", path, offset=offset, iotimeout=1)
@@ -147,7 +165,7 @@ def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset):
 
 
 def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):
-    path = str(tmpdir.join("ls_name"))
+    path = util.generate_path(tmpdir, "ls_name")
     util.create_file(path, 1024**2)
 
     sanlock.write_lockspace("ls_name", path, iotimeout=1)
@@ -189,10 +207,10 @@ def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):
     (LARGE_FILE_SIZE, LARGE_FILE_SIZE - MIN_RES_SIZE),
 ])
 def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
-    ls_path = str(tmpdir.join("ls_name"))
+    ls_path = util.generate_path(tmpdir, "ls_name")
     util.create_file(ls_path, size)
 
-    res_path = str(tmpdir.join("res_name"))
+    res_path = util.generate_path(tmpdir, "res_name")
     util.create_file(res_path, size)
 
     sanlock.write_lockspace("ls_name", ls_path, offset=offset, iotimeout=1)

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -45,22 +45,22 @@ def test_write_lockspace(tmpdir, sanlock_daemon, size, offset, filename, encodin
     util.create_file(path, size)
 
     # Test read and write with default alignment and sector size values.
-    sanlock.write_lockspace("name", path, offset=offset, iotimeout=1)
+    sanlock.write_lockspace(b"name", path, offset=offset, iotimeout=1)
 
     ls = sanlock.read_lockspace(path, offset=offset)
     assert ls == {"iotimeout": 1, "lockspace": b"name"}
 
     # Test read and write with explicit alignment and sector size values.
     sanlock.write_lockspace(
-        "name", path, offset=offset, iotimeout=1, align=ALIGNMENT_1M,
+        b"name", path, offset=offset, iotimeout=1, align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_512)
 
     ls = sanlock.read_lockspace(
         path, offset=offset, align=ALIGNMENT_1M, sector=SECTOR_SIZE_512)
-    assert ls == {"iotimeout": 1, "lockspace": "name"}
+    assert ls == {"iotimeout": 1, "lockspace": b"name"}
 
     acquired = sanlock.inq_lockspace(
-        "name", 1, path, offset=offset, wait=False)
+        b"name", 1, path, offset=offset, wait=False)
     assert acquired is False
 
     with io.open(path, "rb") as f:
@@ -91,7 +91,7 @@ def test_write_resource(tmpdir, sanlock_daemon, size, offset, filename, encoding
     disks = [(path, offset)]
 
     # Test read and write with default alignment and sector size values.
-    sanlock.write_resource("ls_name", "res_name", disks)
+    sanlock.write_resource(b"ls_name", b"res_name", disks)
 
     res = sanlock.read_resource(path, offset=offset)
     assert res == {
@@ -102,18 +102,18 @@ def test_write_resource(tmpdir, sanlock_daemon, size, offset, filename, encoding
 
     # Test read and write with explicit alignment and sector size values.
     sanlock.write_resource(
-        "ls_name", "res_name", disks, align=ALIGNMENT_1M,
+        b"ls_name", b"res_name", disks, align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_512)
 
     res = sanlock.read_resource(
         path, offset=offset, align=ALIGNMENT_1M, sector=SECTOR_SIZE_512)
     assert res == {
-        "lockspace": "ls_name",
-        "resource": "res_name",
+        "lockspace": b"ls_name",
+        "resource": b"res_name",
         "version": 0
     }
 
-    owners = sanlock.read_resource_owners("ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)
     assert owners == []
 
     with io.open(path, "rb") as f:
@@ -142,25 +142,25 @@ def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset, filename, encod
     path = util.generate_path(tmpdir, filename, encoding)
     util.create_file(path, size)
 
-    sanlock.write_lockspace("ls_name", path, offset=offset, iotimeout=1)
+    sanlock.write_lockspace(b"ls_name", path, offset=offset, iotimeout=1)
 
     # Since the lockspace is not acquired, we exepect to get False.
     acquired = sanlock.inq_lockspace(
-        "ls_name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is False
 
-    sanlock.add_lockspace("ls_name", 1, path, offset=offset, iotimeout=1)
+    sanlock.add_lockspace(b"ls_name", 1, path, offset=offset, iotimeout=1)
 
     # Once the lockspace is acquired, we exepect to get True.
     acquired = sanlock.inq_lockspace(
-        "ls_name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is True
 
-    sanlock.rem_lockspace("ls_name", 1, path, offset=offset)
+    sanlock.rem_lockspace(b"ls_name", 1, path, offset=offset)
 
     # Once the lockspace is released, we exepect to get False.
     acquired = sanlock.inq_lockspace(
-        "ls_name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is False
 
 
@@ -168,35 +168,35 @@ def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):
     path = util.generate_path(tmpdir, "ls_name")
     util.create_file(path, 1024**2)
 
-    sanlock.write_lockspace("ls_name", path, iotimeout=1)
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
+    sanlock.write_lockspace(b"ls_name", path, iotimeout=1)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=False)
     assert acquired is False
 
     # This will take 3 seconds.
-    sanlock.add_lockspace("ls_name", 1, path, iotimeout=1, **{"async": True})
+    sanlock.add_lockspace(b"ls_name", 1, path, iotimeout=1, **{"async": True})
 
     # While the lockspace is being aquired, we expect to get None.
     time.sleep(1)
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=False)
     assert acquired is None
 
     # Once the lockspace is acquired, we exepect to get True.
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=True)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=True)
     assert acquired is True
 
     # This will take about 3 seconds.
-    sanlock.rem_lockspace("ls_name", 1, path, **{"async": True})
+    sanlock.rem_lockspace(b"ls_name", 1, path, **{"async": True})
 
     # Wait until the lockspace change state from True to None.
-    while sanlock.inq_lockspace("ls_name", 1, path, wait=False):
+    while sanlock.inq_lockspace(b"ls_name", 1, path, wait=False):
         time.sleep(1)
 
     # While the lockspace is being released, we expect to get None.
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=False)
     assert acquired is None
 
     # Once the lockspace was released, we expect to get False.
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=True)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=True)
     assert acquired is False
 
 
@@ -213,20 +213,20 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
     res_path = util.generate_path(tmpdir, "res_name")
     util.create_file(res_path, size)
 
-    sanlock.write_lockspace("ls_name", ls_path, offset=offset, iotimeout=1)
-    sanlock.add_lockspace("ls_name", 1, ls_path, offset=offset, iotimeout=1)
+    sanlock.write_lockspace(b"ls_name", ls_path, offset=offset, iotimeout=1)
+    sanlock.add_lockspace(b"ls_name", 1, ls_path, offset=offset, iotimeout=1)
 
     # Host status is not available until the first renewal.
     with pytest.raises(sanlock.SanlockException) as e:
-        sanlock.get_hosts("ls_name", 1)
+        sanlock.get_hosts(b"ls_name", 1)
     assert e.value.errno == errno.EAGAIN
 
     time.sleep(1)
-    host = sanlock.get_hosts("ls_name", 1)[0]
+    host = sanlock.get_hosts(b"ls_name", 1)[0]
     assert host["flags"] == sanlock.HOST_LIVE
 
     disks = [(res_path, offset)]
-    sanlock.write_resource("ls_name", "res_name", disks)
+    sanlock.write_resource(b"ls_name", b"res_name", disks)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -235,11 +235,11 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 0
     }
 
-    owners = sanlock.read_resource_owners("ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)
     assert owners == []
 
     fd = sanlock.register()
-    sanlock.acquire("ls_name", "res_name", disks, slkfd=fd)
+    sanlock.acquire(b"ls_name", b"res_name", disks, slkfd=fd)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -248,7 +248,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 1
     }
 
-    owner = sanlock.read_resource_owners("ls_name", "res_name", disks)[0]
+    owner = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)[0]
 
     assert owner["host_id"] == 1
     assert owner["flags"] == 0
@@ -256,11 +256,11 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
     assert owner["io_timeout"] == 0  # Why 0?
     # TODO: check timestamp.
 
-    host = sanlock.get_hosts("ls_name", 1)[0]
+    host = sanlock.get_hosts(b"ls_name", 1)[0]
     assert host["flags"] == sanlock.HOST_LIVE
     assert host["generation"] == owner["generation"]
 
-    sanlock.release("ls_name", "res_name", disks, slkfd=fd)
+    sanlock.release(b"ls_name", b"res_name", disks, slkfd=fd)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -269,7 +269,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 1
     }
 
-    owners = sanlock.read_resource_owners("ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)
     assert owners == []
 
 
@@ -285,7 +285,7 @@ def test_write_lockspace_invalid_align_sector(
     util.create_file(path, LOCKSPACE_SIZE)
 
     with pytest.raises(ValueError):
-        sanlock.write_lockspace("name", path, align=align, sector=sector)
+        sanlock.write_lockspace(b"name", path, align=align, sector=sector)
 
 
 @pytest.mark.parametrize("align, sector", [
@@ -302,4 +302,4 @@ def test_write_resource_invalid_align_sector(
 
     with pytest.raises(ValueError):
         sanlock.write_resource(
-            "ls_name", "res_name", disks, align=align, sector=sector)
+            b"ls_name", b"res_name", disks, align=align, sector=sector)

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -1,6 +1,7 @@
 """
 Test sanlock python binding with sanlock daemon.
 """
+from __future__ import absolute_import
 
 import errno
 import io

--- a/tests/util.py
+++ b/tests/util.py
@@ -134,3 +134,10 @@ def check_rindex_entry(entry, name, offset=None, flags=None):
 
     if flags is not None:
         assert e_flags == flags
+
+
+def generate_path(dirname, filename, encoding=None):
+    path = os.path.join(str(dirname), filename)
+    if encoding is not None:
+        path = path.encode(encoding)
+    return path

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,6 +1,7 @@
 """
 Testing utilities
 """
+from __future__ import absolute_import
 
 import errno
 import io

--- a/tests/util.py
+++ b/tests/util.py
@@ -60,8 +60,8 @@ def wait_for_daemon(timeout):
             try:
                 s.connect(path)
                 return
-            except socket.error as e:
-                if e[0] not in (errno.ECONNREFUSED, errno.ENOENT):
+            except EnvironmentError as e:
+                if e.errno not in (errno.ECONNREFUSED, errno.ENOENT):
                     raise  # Unexpected error
             if time.time() > deadline:
                 raise TimeoutExpired

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,8 @@ whitelist_externals = make
 deps =
     pytest==4.0
 commands =
-    make BUILDARGS="--build-lib={envsitepackagesdir}"
+    py27: make PY_VERSION=2.7 BUILDARGS="--build-lib={envsitepackagesdir}"
+    py36: make PY_VERSION=3.6 BUILDARGS="--build-lib={envsitepackagesdir}"
     pytest {posargs}
 
 [pytest]


### PR DESCRIPTION
This PR is based on previous PRs:
1. python 3 preparations: patch set was sent in sanlock-devel mailing
2. resource api should only accept tuple lists: https://github.com/nirs/sanlock/pull/2
2. module init refactoring: https://github.com/nirs/sanlock/pull/3

Current PR adds Python 3 portability, addresses required changes in sanlock module and relevant tests.
