### PR TITLE
Adding Python 3  functionality

### DIFF
--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -366,15 +366,14 @@ static PyObject *
 py_init_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, use_aio = 1;
-    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *lockspace;
+    PyObject *disks, *lockspace, *resource;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "max_hosts",
                                 "num_hosts", "use_aio", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iii",
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|iii",
         kwlist, &lockspace, &resource, &PyList_Type, &disks, &max_hosts,
         &num_hosts, &use_aio)) {
         return NULL;
@@ -387,7 +386,7 @@ py_init_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* init sanlock resource (gil disabled) */
     Py_BEGIN_ALLOW_THREADS
@@ -623,16 +622,15 @@ py_write_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, clear = 0, sector = SECTOR_SIZE_512;
     long align = ALIGNMENT_1M;
-    const char *resource;
     struct sanlk_resource *rs;
-    PyObject *disks, *lockspace;
+    PyObject *disks, *lockspace, *resource;
     uint32_t flags = 0;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "max_hosts",
                                 "num_hosts", "clear", "align", "sector", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iiili",
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|iiili",
         kwlist, &lockspace, &resource, &PyList_Type, &disks, &max_hosts,
         &num_hosts, &clear, &align, &sector)) {
         return NULL;
@@ -645,7 +643,7 @@ py_write_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(rs->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(rs->name, resource, SANLK_NAME_LEN);
+    strncpy(rs->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* set alignment/sector flags */
     if (add_align_flag(align, &rs->flags) == -1)
@@ -966,15 +964,14 @@ static PyObject *
 py_acquire(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, sanlockfd = -1, pid = -1, shared = 0;
-    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *version = Py_None, *lockspace;
+    PyObject *disks, *version = Py_None, *lockspace, *resource;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "slkfd",
                                 "pid", "shared", "version", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iiiO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|iiiO", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &sanlockfd, &pid,
         &shared, &version)) {
         return NULL;
@@ -993,7 +990,7 @@ py_acquire(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* prepare sanlock flags */
     if (shared) {
@@ -1038,15 +1035,14 @@ static PyObject *
 py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, sanlockfd = -1, pid = -1;
-    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *lockspace;
+    PyObject *disks, *lockspace, *resource;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "slkfd",
                                 "pid", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|ii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|ii", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &sanlockfd, &pid)) {
         return NULL;
     }
@@ -1058,7 +1054,7 @@ py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* release sanlock resource (gil disabled) */
     Py_BEGIN_ALLOW_THREADS
@@ -1092,15 +1088,14 @@ static PyObject *
 py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, action = SANLK_REQ_GRACEFUL, flags = 0;
-    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *version = Py_None, *lockspace;
+    PyObject *disks, *version = Py_None, *lockspace, *resource;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "action",
                                 "version", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|iO", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &action, &version)) {
         return NULL;
     }
@@ -1112,7 +1107,7 @@ py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* prepare the resource version */
     if (version == Py_None) {
@@ -1161,16 +1156,15 @@ py_read_resource_owners(PyObject *self __unused, PyObject *args, PyObject *keywd
     int rv, hss_count = 0;
     int sector = SECTOR_SIZE_512;
     long align = ALIGNMENT_1M;
-    const char *resource;
     struct sanlk_resource *res = NULL;
     struct sanlk_host *hss = NULL;
-    PyObject *disks, *ls_list = NULL, *lockspace;
+    PyObject *disks, *ls_list = NULL, *lockspace, *resource;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "align",
                              "sector", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|li", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SSO!|li", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &align, &sector)) {
         return NULL;
     }
@@ -1182,7 +1176,7 @@ py_read_resource_owners(PyObject *self __unused, PyObject *args, PyObject *keywd
 
     /* prepare sanlock names */
     strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* set resource alignment and sector flags */
 

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -320,8 +320,9 @@ static PyObject *
 py_init_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, use_aio = 1;
-    const char *lockspace, *path;
+    const char *path;
     struct sanlk_lockspace ls;
+    PyObject *lockspace;
 
     static char *kwlist[] = {"lockspace", "path", "offset",
                                 "max_hosts", "num_hosts", "use_aio", NULL};
@@ -330,14 +331,14 @@ py_init_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ss|kiii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "Ss|kiii", kwlist,
         &lockspace, &path, &ls.host_id_disk.offset, &max_hosts,
         &num_hosts, &use_aio)) {
         return NULL;
     }
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, path, SANLK_PATH_LEN - 1);
 
     /* init sanlock lockspace (gil disabled) */
@@ -365,15 +366,15 @@ static PyObject *
 py_init_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, use_aio = 1;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks;
+    PyObject *disks, *lockspace;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "max_hosts",
                                 "num_hosts", "use_aio", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|iii",
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iii",
         kwlist, &lockspace, &resource, &PyList_Type, &disks, &max_hosts,
         &num_hosts, &use_aio)) {
         return NULL;
@@ -385,7 +386,7 @@ py_init_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* init sanlock resource (gil disabled) */
@@ -420,8 +421,9 @@ py_write_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     int rv, max_hosts = 0, sector = SECTOR_SIZE_512;
     long align = ALIGNMENT_1M;
     uint32_t io_timeout = 0;
-    const char *lockspace, *path;
+    const char *path;
     struct sanlk_lockspace ls;
+    PyObject *lockspace;
 
     static char *kwlist[] = {"lockspace", "path", "offset", "max_hosts",
                                 "iotimeout", "align", "sector", NULL};
@@ -430,14 +432,14 @@ py_write_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ss|kiIli", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "Ss|kiIli", kwlist,
         &lockspace, &path, &ls.host_id_disk.offset, &max_hosts,
         &io_timeout, &align, &sector)) {
         return NULL;
     }
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, path, SANLK_PATH_LEN - 1);
 
     /* set alignment/sector flags */
@@ -621,16 +623,16 @@ py_write_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, max_hosts = 0, num_hosts = 0, clear = 0, sector = SECTOR_SIZE_512;
     long align = ALIGNMENT_1M;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *rs;
-    PyObject *disks;
+    PyObject *disks, *lockspace;
     uint32_t flags = 0;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "max_hosts",
                                 "num_hosts", "clear", "align", "sector", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|iiili",
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iiili",
         kwlist, &lockspace, &resource, &PyList_Type, &disks, &max_hosts,
         &num_hosts, &clear, &align, &sector)) {
         return NULL;
@@ -642,7 +644,7 @@ py_write_resource(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(rs->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(rs->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(rs->name, resource, SANLK_NAME_LEN);
 
     /* set alignment/sector flags */
@@ -687,8 +689,9 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, async = 0, flags = 0;
     uint32_t iotimeout = 0;
-    const char *lockspace, *path;
+    const char *path;
     struct sanlk_lockspace ls;
+    PyObject *lockspace;
 
     static char *kwlist[] = {"lockspace", "host_id", "path", "offset",
                                 "iotimeout", "async", NULL};
@@ -697,7 +700,7 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "sks|kIi", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "Sks|kIi", kwlist,
         &lockspace, &ls.host_id, &path, &ls.host_id_disk.offset, &iotimeout,
         &async)) {
         return NULL;
@@ -709,7 +712,7 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, path, SANLK_PATH_LEN - 1);
 
     /* add sanlock lockspace (gil disabled) */
@@ -738,8 +741,9 @@ static PyObject *
 py_inq_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, waitrs = 0, flags = 0;
-    const char *lockspace, *path;
+    const char *path;
     struct sanlk_lockspace ls;
+    PyObject *lockspace;
 
     static char *kwlist[] = {"lockspace", "host_id", "path", "offset",
                                 "wait", NULL};
@@ -748,7 +752,7 @@ py_inq_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "sks|ki", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "Sks|ki", kwlist,
         &lockspace, &ls.host_id, &path, &ls.host_id_disk.offset,
         &waitrs)) {
         return NULL;
@@ -760,7 +764,7 @@ py_inq_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, path, SANLK_PATH_LEN - 1);
 
     /* add sanlock lockspace (gil disabled) */
@@ -794,8 +798,9 @@ static PyObject *
 py_rem_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, async = 0, unused = 0, flags = 0;
-    const char *lockspace, *path;
+    const char *path;
     struct sanlk_lockspace ls;
+    PyObject *lockspace;
 
     static char *kwlist[] = {"lockspace", "host_id", "path", "offset",
                                 "async", "unused", NULL};
@@ -804,14 +809,14 @@ py_rem_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "sks|kii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "Sks|kii", kwlist,
         &lockspace, &ls.host_id, &path, &ls.host_id_disk.offset, &async,
         &unused)) {
         return NULL;
     }
 
     /* prepare sanlock names */
-    strncpy(ls.name, lockspace, SANLK_NAME_LEN);
+    strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(ls.host_id_disk.path, path, SANLK_PATH_LEN - 1);
 
     /* prepare sanlock_rem_lockspace flags */
@@ -918,21 +923,21 @@ py_get_hosts(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, hss_count = 0;
     uint64_t host_id = 0;
-    const char *lockspace = NULL;
+    PyObject *lockspace = NULL;
     struct sanlk_host *hss = NULL;
     PyObject *ls_list = NULL;
 
     static char *kwlist[] = {"lockspace", "host_id", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s|k", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "S|k", kwlist,
         &lockspace, &host_id)) {
         return NULL;
     }
 
     /* get all the lockspaces (gil disabled) */
     Py_BEGIN_ALLOW_THREADS
-    rv = sanlock_get_hosts(lockspace, host_id, &hss, &hss_count, 0);
+    rv = sanlock_get_hosts(PyBytes_AsString(lockspace), host_id, &hss, &hss_count, 0);
     Py_END_ALLOW_THREADS
 
     if (rv < 0) {
@@ -961,15 +966,15 @@ static PyObject *
 py_acquire(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, sanlockfd = -1, pid = -1, shared = 0;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *version = Py_None;
+    PyObject *disks, *version = Py_None, *lockspace;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "slkfd",
                                 "pid", "shared", "version", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|iiiO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iiiO", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &sanlockfd, &pid,
         &shared, &version)) {
         return NULL;
@@ -987,7 +992,7 @@ py_acquire(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* prepare sanlock flags */
@@ -1033,15 +1038,15 @@ static PyObject *
 py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, sanlockfd = -1, pid = -1;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks;
+    PyObject *disks, *lockspace;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "slkfd",
                                 "pid", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|ii", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|ii", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &sanlockfd, &pid)) {
         return NULL;
     }
@@ -1052,7 +1057,7 @@ py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* release sanlock resource (gil disabled) */
@@ -1087,15 +1092,15 @@ static PyObject *
 py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv, action = SANLK_REQ_GRACEFUL, flags = 0;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res;
-    PyObject *disks, *version = Py_None;
+    PyObject *disks, *version = Py_None, *lockspace;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "action",
                                 "version", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|iO", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|iO", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &action, &version)) {
         return NULL;
     }
@@ -1106,7 +1111,7 @@ py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* prepare the resource version */
@@ -1156,16 +1161,16 @@ py_read_resource_owners(PyObject *self __unused, PyObject *args, PyObject *keywd
     int rv, hss_count = 0;
     int sector = SECTOR_SIZE_512;
     long align = ALIGNMENT_1M;
-    const char *lockspace, *resource;
+    const char *resource;
     struct sanlk_resource *res = NULL;
     struct sanlk_host *hss = NULL;
-    PyObject *disks, *ls_list = NULL;
+    PyObject *disks, *ls_list = NULL, *lockspace;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "align",
                              "sector", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|li", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SsO!|li", kwlist,
         &lockspace, &resource, &PyList_Type, &disks, &align, &sector)) {
         return NULL;
     }
@@ -1176,7 +1181,7 @@ py_read_resource_owners(PyObject *self __unused, PyObject *args, PyObject *keywd
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
     strncpy(res->name, resource, SANLK_NAME_LEN);
 
     /* set resource alignment and sector flags */
@@ -1316,14 +1321,14 @@ unregister the event listener using end_event.");
 static PyObject *
 py_reg_event(PyObject *self __unused, PyObject *args)
 {
-    const char *lockspace = NULL;
+    PyObject *lockspace = NULL;
     int fd = -1;
 
-    if (!PyArg_ParseTuple(args, "s", &lockspace))
+    if (!PyArg_ParseTuple(args, "S", &lockspace))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
-    fd = sanlock_reg_event(lockspace, NULL /* event */, 0 /* flags */);
+    fd = sanlock_reg_event(PyBytes_AsString(lockspace), NULL /* event */, 0 /* flags */);
     Py_END_ALLOW_THREADS
 
     if (fd < 0) {
@@ -1454,14 +1459,14 @@ static PyObject *
 py_end_event(PyObject *self __unused, PyObject *args)
 {
     int fd = -1;
-    const char *lockspace = NULL;
+    PyObject *lockspace = NULL;
     int rv;
 
-    if (!PyArg_ParseTuple(args, "is", &fd, &lockspace))
+    if (!PyArg_ParseTuple(args, "iS", &fd, &lockspace))
         return NULL;
 
     Py_BEGIN_ALLOW_THREADS
-    rv = sanlock_end_event(fd, lockspace, 0 /* flags */);
+    rv = sanlock_end_event(fd, PyBytes_AsString(lockspace), 0 /* flags */);
     Py_END_ALLOW_THREADS
 
     if (rv < 0) {
@@ -1527,7 +1532,7 @@ with -EBUSY error in this case.\n\
 static PyObject *
 py_set_event(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
-    const char *lockspace;
+    PyObject *lockspace;
     struct sanlk_host_event he = {0};
     uint32_t flags = 0;
     int rv;
@@ -1535,14 +1540,14 @@ py_set_event(PyObject *self __unused, PyObject *args, PyObject *keywds)
     static char *kwlist[] = {"lockspace", "host_id", "generation", "event",
                              "data", "flags", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "sKKK|KI", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "SKKK|KI", kwlist,
         &lockspace, &he.host_id, &he.generation, &he.event, &he.data,
         &flags)) {
         return NULL;
     }
 
     Py_BEGIN_ALLOW_THREADS
-    rv = sanlock_set_event(lockspace, &he, flags);
+    rv = sanlock_set_event(PyBytes_AsString(lockspace), &he, flags);
     Py_END_ALLOW_THREADS
 
     if (rv < 0) {

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -305,12 +305,24 @@ def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset):
         "ls_name", 1, path, offset=offset, wait=False)
     assert acquired is True
 
+    lockspaces = sanlock.get_lockspaces()
+    assert lockspaces == [{
+        'flags': 0,
+        'host_id': 1,
+        'lockspace': b'ls_name',
+        'offset': offset,
+        'path': path
+    }]
+
     sanlock.rem_lockspace("ls_name", 1, path, offset=offset)
 
     # Once the lockspace is released, we exepect to get False.
     acquired = sanlock.inq_lockspace(
         "ls_name", 1, path, offset=offset, wait=False)
     assert acquired is False
+
+    lockspaces = sanlock.get_lockspaces()
+    assert lockspaces == []
 
 
 def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -61,14 +61,14 @@ def test_write_lockspace(tmpdir, sanlock_daemon, filename, encoding, size, offse
     util.create_file(path, size)
 
     # Test read and write with default alignment and sector size values.
-    sanlock.write_lockspace("name", path, offset=offset, iotimeout=1)
+    sanlock.write_lockspace(b"name", path, offset=offset, iotimeout=1)
 
     ls = sanlock.read_lockspace(path, offset=offset)
     assert ls == {"iotimeout": 1, "lockspace": b"name"}
 
     # Test read and write with explicit alignment and sector size values.
     sanlock.write_lockspace(
-        "name", path, offset=offset, iotimeout=1, align=ALIGNMENT_1M,
+        b"name", path, offset=offset, iotimeout=1, align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_512)
 
     ls = sanlock.read_lockspace(
@@ -76,7 +76,7 @@ def test_write_lockspace(tmpdir, sanlock_daemon, filename, encoding, size, offse
     assert ls == {"iotimeout": 1, "lockspace": b"name"}
 
     acquired = sanlock.inq_lockspace(
-        "name", 1, path, offset=offset, wait=False)
+        b"name", 1, path, offset=offset, wait=False)
     assert acquired is False
 
     with io.open(path, "rb") as f:
@@ -99,14 +99,14 @@ def test_write_lockspace_4k(user_4k_path, sanlock_daemon, align):
     util.write_guard(user_4k_path, align)
 
     sanlock.write_lockspace(
-        "name", user_4k_path, iotimeout=1, align=align, sector=SECTOR_SIZE_4K)
+        b"name", user_4k_path, iotimeout=1, align=align, sector=SECTOR_SIZE_4K)
 
     ls = sanlock.read_lockspace(
         user_4k_path, align=align, sector=SECTOR_SIZE_4K)
 
     assert ls == {"iotimeout": 1, "lockspace": b"name"}
 
-    acquired = sanlock.inq_lockspace("name", 1, user_4k_path, wait=False)
+    acquired = sanlock.inq_lockspace(b"name", 1, user_4k_path, wait=False)
     assert acquired is False
 
     # Verify that lockspace was written.
@@ -121,13 +121,13 @@ def test_write_lockspace_4k(user_4k_path, sanlock_daemon, align):
 def test_write_lockspace_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.write_lockspace(
-            "name", user_4k_path, iotimeout=1, sector=SECTOR_SIZE_512)
+            b"name", user_4k_path, iotimeout=1, sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
 def test_read_lockspace_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     sanlock.write_lockspace(
-        "name", user_4k_path, iotimeout=1, sector=SECTOR_SIZE_4K)
+        b"name", user_4k_path, iotimeout=1, sector=SECTOR_SIZE_4K)
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.read_lockspace(user_4k_path, sector=SECTOR_SIZE_512)
@@ -147,7 +147,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
     disks = [(path, offset)]
 
     # Test read and write with default alignment and sector size values.
-    sanlock.write_resource("ls_name", "res_name", disks)
+    sanlock.write_resource(b"ls_name", "res_name", disks)
 
     res = sanlock.read_resource(path, offset=offset)
     assert res == {
@@ -158,7 +158,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
 
     # Test read and write with explicit alignment and sector size values.
     sanlock.write_resource(
-        "ls_name", "res_name", disks, align=ALIGNMENT_1M,
+        b"ls_name", "res_name", disks, align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_512)
 
     res = sanlock.read_resource(
@@ -169,7 +169,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
         "version": 0
     }
 
-    owners = sanlock.read_resource_owners("ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", "res_name", disks)
     assert owners == []
 
     with io.open(path, "rb") as f:
@@ -193,7 +193,7 @@ def test_write_resource_4k(sanlock_daemon, user_4k_path, align):
     util.write_guard(user_4k_path, align)
 
     sanlock.write_resource(
-        "ls_name", "res_name", disks, align=align, sector=SECTOR_SIZE_4K)
+        b"ls_name", "res_name", disks, align=align, sector=SECTOR_SIZE_4K)
 
     res = sanlock.read_resource(
         user_4k_path, align=align, sector=SECTOR_SIZE_4K)
@@ -205,7 +205,7 @@ def test_write_resource_4k(sanlock_daemon, user_4k_path, align):
     }
 
     owners = sanlock.read_resource_owners(
-        "ls_name", "res_name", disks, align=align, sector=SECTOR_SIZE_4K)
+        b"ls_name", "res_name", disks, align=align, sector=SECTOR_SIZE_4K)
     assert owners == []
 
     # Verify that resource was written.
@@ -223,7 +223,7 @@ def test_write_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.write_resource(
-            "ls_name", "res_name", disks, sector=SECTOR_SIZE_512)
+            b"ls_name", "res_name", disks, sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
@@ -231,7 +231,7 @@ def test_read_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     disks = [(user_4k_path, 0)]
 
     sanlock.write_resource(
-        "ls_name",
+        b"ls_name",
         "res_name",
         disks,
         align=ALIGNMENT_1M,
@@ -247,7 +247,7 @@ def test_read_resource_owners_4k_invalid_sector_size(
     disks = [(user_4k_path, 0)]
 
     sanlock.write_resource(
-        "ls_name",
+        b"ls_name",
         "res_name",
         disks,
         align=ALIGNMENT_1M,
@@ -255,7 +255,7 @@ def test_read_resource_owners_4k_invalid_sector_size(
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.read_resource_owners(
-            "ls_name", "res_name", disks, sector=SECTOR_SIZE_512)
+            b"ls_name", "res_name", disks, sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
@@ -265,7 +265,7 @@ def test_read_resource_owners_invalid_align_size(tmpdir, sanlock_daemon):
     disks = [(path, 0)]
 
     sanlock.write_resource(
-        "ls_name",
+        b"ls_name",
         "res_name",
         disks,
         align=ALIGNMENT_1M,
@@ -273,7 +273,7 @@ def test_read_resource_owners_invalid_align_size(tmpdir, sanlock_daemon):
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.read_resource_owners(
-            "ls_name",
+            b"ls_name",
             "res_name",
             disks,
             align=ALIGNMENT_2M,
@@ -291,18 +291,18 @@ def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset):
     path = str(tmpdir.join("ls_name"))
     util.create_file(path, size)
 
-    sanlock.write_lockspace("ls_name", path, offset=offset, iotimeout=1)
+    sanlock.write_lockspace(b"ls_name", path, offset=offset, iotimeout=1)
 
     # Since the lockspace is not acquired, we exepect to get False.
     acquired = sanlock.inq_lockspace(
-        "ls_name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is False
 
-    sanlock.add_lockspace("ls_name", 1, path, offset=offset, iotimeout=1)
+    sanlock.add_lockspace(b"ls_name", 1, path, offset=offset, iotimeout=1)
 
     # Once the lockspace is acquired, we exepect to get True.
     acquired = sanlock.inq_lockspace(
-        "ls_name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is True
 
     lockspaces = sanlock.get_lockspaces()
@@ -314,11 +314,11 @@ def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset):
         'path': path
     }]
 
-    sanlock.rem_lockspace("ls_name", 1, path, offset=offset)
+    sanlock.rem_lockspace(b"ls_name", 1, path, offset=offset)
 
     # Once the lockspace is released, we exepect to get False.
     acquired = sanlock.inq_lockspace(
-        "ls_name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is False
 
     lockspaces = sanlock.get_lockspaces()
@@ -329,35 +329,35 @@ def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):
     path = str(tmpdir.join("ls_name"))
     util.create_file(path, MiB)
 
-    sanlock.write_lockspace("ls_name", path, iotimeout=1)
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
+    sanlock.write_lockspace(b"ls_name", path, iotimeout=1)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=False)
     assert acquired is False
 
     # This will take 3 seconds.
-    sanlock.add_lockspace("ls_name", 1, path, iotimeout=1, **{"async": True})
+    sanlock.add_lockspace(b"ls_name", 1, path, iotimeout=1, **{"async": True})
 
     # While the lockspace is being aquired, we expect to get None.
     time.sleep(1)
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=False)
     assert acquired is None
 
     # Once the lockspace is acquired, we exepect to get True.
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=True)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=True)
     assert acquired is True
 
     # This will take about 3 seconds.
-    sanlock.rem_lockspace("ls_name", 1, path, **{"async": True})
+    sanlock.rem_lockspace(b"ls_name", 1, path, **{"async": True})
 
     # Wait until the lockspace change state from True to None.
-    while sanlock.inq_lockspace("ls_name", 1, path, wait=False):
+    while sanlock.inq_lockspace(b"ls_name", 1, path, wait=False):
         time.sleep(1)
 
     # While the lockspace is being released, we expect to get None.
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=False)
     assert acquired is None
 
     # Once the lockspace was released, we expect to get False.
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=True)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=True)
     assert acquired is False
 
 
@@ -374,20 +374,20 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
     res_path = str(tmpdir.join("res_name"))
     util.create_file(res_path, size)
 
-    sanlock.write_lockspace("ls_name", ls_path, offset=offset, iotimeout=1)
-    sanlock.add_lockspace("ls_name", 1, ls_path, offset=offset, iotimeout=1)
+    sanlock.write_lockspace(b"ls_name", ls_path, offset=offset, iotimeout=1)
+    sanlock.add_lockspace(b"ls_name", 1, ls_path, offset=offset, iotimeout=1)
 
     # Host status is not available until the first renewal.
     with pytest.raises(sanlock.SanlockException) as e:
-        sanlock.get_hosts("ls_name", 1)
+        sanlock.get_hosts(b"ls_name", 1)
     assert e.value.errno == errno.EAGAIN
 
     time.sleep(1)
-    host = sanlock.get_hosts("ls_name", 1)[0]
+    host = sanlock.get_hosts(b"ls_name", 1)[0]
     assert host["flags"] == sanlock.HOST_LIVE
 
     disks = [(res_path, offset)]
-    sanlock.write_resource("ls_name", "res_name", disks)
+    sanlock.write_resource(b"ls_name", "res_name", disks)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -396,11 +396,11 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 0
     }
 
-    owners = sanlock.read_resource_owners("ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", "res_name", disks)
     assert owners == []
 
     fd = sanlock.register()
-    sanlock.acquire("ls_name", "res_name", disks, slkfd=fd)
+    sanlock.acquire(b"ls_name", "res_name", disks, slkfd=fd)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -409,7 +409,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 1
     }
 
-    owner = sanlock.read_resource_owners("ls_name", "res_name", disks)[0]
+    owner = sanlock.read_resource_owners(b"ls_name", "res_name", disks)[0]
 
     assert owner["host_id"] == 1
     assert owner["flags"] == 0
@@ -417,11 +417,11 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
     assert owner["io_timeout"] == 0  # Why 0?
     # TODO: check timestamp.
 
-    host = sanlock.get_hosts("ls_name", 1)[0]
+    host = sanlock.get_hosts(b"ls_name", 1)[0]
     assert host["flags"] == sanlock.HOST_LIVE
     assert host["generation"] == owner["generation"]
 
-    sanlock.release("ls_name", "res_name", disks, slkfd=fd)
+    sanlock.release(b"ls_name", "res_name", disks, slkfd=fd)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -430,7 +430,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 1
     }
 
-    owners = sanlock.read_resource_owners("ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", "res_name", disks)
     assert owners == []
 
 
@@ -446,7 +446,7 @@ def test_write_lockspace_invalid_align_sector(
     util.create_file(path, LOCKSPACE_SIZE)
 
     with pytest.raises(ValueError):
-        sanlock.write_lockspace("name", path, align=align, sector=sector)
+        sanlock.write_lockspace(b"name", path, align=align, sector=sector)
 
 
 @pytest.mark.parametrize("align, sector", [
@@ -463,7 +463,7 @@ def test_write_resource_invalid_align_sector(
 
     with pytest.raises(ValueError):
         sanlock.write_resource(
-            "ls_name", "res_name", disks, align=align, sector=sector)
+            b"ls_name", "res_name", disks, align=align, sector=sector)
 
 
 @pytest.mark.parametrize("disk", [
@@ -484,6 +484,6 @@ def test_write_resource_invalid_disk(tmpdir, sanlock_daemon, disk):
     # Test parsing disks list with invalid content.
     disks = [disk]
     with pytest.raises(ValueError) as e:
-        sanlock.write_resource("ls_name", "res_name", disks)
+        sanlock.write_resource(b"ls_name", "res_name", disks)
     assert repr(disk) in str(e.value)
 

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -147,7 +147,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
     disks = [(path, offset)]
 
     # Test read and write with default alignment and sector size values.
-    sanlock.write_resource(b"ls_name", "res_name", disks)
+    sanlock.write_resource(b"ls_name", b"res_name", disks)
 
     res = sanlock.read_resource(path, offset=offset)
     assert res == {
@@ -158,7 +158,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
 
     # Test read and write with explicit alignment and sector size values.
     sanlock.write_resource(
-        b"ls_name", "res_name", disks, align=ALIGNMENT_1M,
+        b"ls_name", b"res_name", disks, align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_512)
 
     res = sanlock.read_resource(
@@ -169,7 +169,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
         "version": 0
     }
 
-    owners = sanlock.read_resource_owners(b"ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)
     assert owners == []
 
     with io.open(path, "rb") as f:
@@ -193,7 +193,7 @@ def test_write_resource_4k(sanlock_daemon, user_4k_path, align):
     util.write_guard(user_4k_path, align)
 
     sanlock.write_resource(
-        b"ls_name", "res_name", disks, align=align, sector=SECTOR_SIZE_4K)
+        b"ls_name", b"res_name", disks, align=align, sector=SECTOR_SIZE_4K)
 
     res = sanlock.read_resource(
         user_4k_path, align=align, sector=SECTOR_SIZE_4K)
@@ -205,7 +205,7 @@ def test_write_resource_4k(sanlock_daemon, user_4k_path, align):
     }
 
     owners = sanlock.read_resource_owners(
-        b"ls_name", "res_name", disks, align=align, sector=SECTOR_SIZE_4K)
+        b"ls_name", b"res_name", disks, align=align, sector=SECTOR_SIZE_4K)
     assert owners == []
 
     # Verify that resource was written.
@@ -223,7 +223,7 @@ def test_write_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.write_resource(
-            b"ls_name", "res_name", disks, sector=SECTOR_SIZE_512)
+            b"ls_name", b"res_name", disks, sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
@@ -232,7 +232,7 @@ def test_read_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
 
     sanlock.write_resource(
         b"ls_name",
-        "res_name",
+        b"res_name",
         disks,
         align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_4K)
@@ -248,14 +248,14 @@ def test_read_resource_owners_4k_invalid_sector_size(
 
     sanlock.write_resource(
         b"ls_name",
-        "res_name",
+        b"res_name",
         disks,
         align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_4K)
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.read_resource_owners(
-            b"ls_name", "res_name", disks, sector=SECTOR_SIZE_512)
+            b"ls_name", b"res_name", disks, sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
@@ -266,7 +266,7 @@ def test_read_resource_owners_invalid_align_size(tmpdir, sanlock_daemon):
 
     sanlock.write_resource(
         b"ls_name",
-        "res_name",
+        b"res_name",
         disks,
         align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_512)
@@ -274,7 +274,7 @@ def test_read_resource_owners_invalid_align_size(tmpdir, sanlock_daemon):
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.read_resource_owners(
             b"ls_name",
-            "res_name",
+            b"res_name",
             disks,
             align=ALIGNMENT_2M,
             sector=SECTOR_SIZE_512)
@@ -387,7 +387,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
     assert host["flags"] == sanlock.HOST_LIVE
 
     disks = [(res_path, offset)]
-    sanlock.write_resource(b"ls_name", "res_name", disks)
+    sanlock.write_resource(b"ls_name", b"res_name", disks)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -396,11 +396,11 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 0
     }
 
-    owners = sanlock.read_resource_owners(b"ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)
     assert owners == []
 
     fd = sanlock.register()
-    sanlock.acquire(b"ls_name", "res_name", disks, slkfd=fd)
+    sanlock.acquire(b"ls_name", b"res_name", disks, slkfd=fd)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -409,7 +409,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 1
     }
 
-    owner = sanlock.read_resource_owners(b"ls_name", "res_name", disks)[0]
+    owner = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)[0]
 
     assert owner["host_id"] == 1
     assert owner["flags"] == 0
@@ -421,7 +421,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
     assert host["flags"] == sanlock.HOST_LIVE
     assert host["generation"] == owner["generation"]
 
-    sanlock.release(b"ls_name", "res_name", disks, slkfd=fd)
+    sanlock.release(b"ls_name", b"res_name", disks, slkfd=fd)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -430,7 +430,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 1
     }
 
-    owners = sanlock.read_resource_owners(b"ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)
     assert owners == []
 
 
@@ -463,7 +463,7 @@ def test_write_resource_invalid_align_sector(
 
     with pytest.raises(ValueError):
         sanlock.write_resource(
-            b"ls_name", "res_name", disks, align=align, sector=sector)
+            b"ls_name", b"res_name", disks, align=align, sector=sector)
 
 
 @pytest.mark.parametrize("disk", [
@@ -484,6 +484,6 @@ def test_write_resource_invalid_disk(tmpdir, sanlock_daemon, disk):
     # Test parsing disks list with invalid content.
     disks = [disk]
     with pytest.raises(ValueError) as e:
-        sanlock.write_resource(b"ls_name", "res_name", disks)
+        sanlock.write_resource(b"ls_name", b"res_name", disks)
     assert repr(disk) in str(e.value)
 


### PR DESCRIPTION
This PR contains the core patches required for sanlock python 3 compatability.
We still need to add the path converter and handle resource and lockspace names a bytes