### PR TITLE
Fix typos in debug logs and comments.

### DIFF
--- a/src/direct.c
+++ b/src/direct.c
@@ -339,7 +339,7 @@ static int do_delta_action(int action,
 
 	switch (action) {
 	case ACT_DIRECT_INIT:
-		/* delta_lease_init looks at ls->flags for sector/align sizses */
+		/* delta_lease_init looks at ls->flags for sector/align sizes */
 
 		rv = delta_lease_init(task, ls, io_timeout, &sd);
 		break;

--- a/src/resource.c
+++ b/src/resource.c
@@ -228,7 +228,7 @@ int read_resource_owners(struct task *task, struct token *token,
 	 */
 	if ((token->sector_size != leader.sector_size) ||
 	    (token->align_size != align_size)) {
-		log_debug("read_resource_owners rereading with correct sizses");
+		log_debug("read_resource_owners rereading with correct sizes");
 		token->sector_size = leader.sector_size;
 		token->align_size  = align_size;
 		free(lease_buf);


### PR DESCRIPTION
Fix typos in debug logs and comments.