### PR TITLE
tests: Remove stale symlinks to loop device on storage setup 

### DIFF
--- a/tests/storage.py
+++ b/tests/storage.py
@@ -84,6 +84,9 @@ def create_loop_device(link_path, backing_file, size=1024**3,
 
     device = out.decode("utf-8").strip()
 
+    #remove stale symlink
+    if os.path.islink(link_path):
+        os.unlink(link_path)
     os.symlink(device, link_path)
     chown(link_path)
 


### PR DESCRIPTION
os.symlink(device, link_path) may fail - so we need to delete stale symlink in setup.

This will happen since loop devices create for tests are not persistent between reboots,
so doing:

    python tests/storage.py setup
    reboot
    python tests/storage.py setup

Will result in stale symlinks for non-existing loop devices on last call
to storage setup.