### PR TITLE
Parse lockspace and resource names as bytes

### DIFF
--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -1538,14 +1538,15 @@ static PyObject *
 py_end_event(PyObject *self __unused, PyObject *args)
 {
     int fd = -1;
-    const char *lockspace = NULL;
-    int rv;
+    PyObject *lockspace = NULL;
+    int rv = -1;
 
-    if (!PyArg_ParseTuple(args, "is", &fd, &lockspace))
-        return NULL;
+    if (!PyArg_ParseTuple(args, "iO&", &fd, convert_to_pybytes, &lockspace)) {
+        goto finally;
+    }
 
     Py_BEGIN_ALLOW_THREADS
-    rv = sanlock_end_event(fd, lockspace, 0 /* flags */);
+    rv = sanlock_end_event(fd, PyBytes_AsString(lockspace), 0 /* flags */);
     Py_END_ALLOW_THREADS
 
     if (rv < 0) {
@@ -1553,6 +1554,10 @@ py_end_event(PyObject *self __unused, PyObject *args)
         return NULL;
     }
 
+finally:
+    Py_XDECREF(lockspace);
+    if (rv < 0)
+        return NULL;
     Py_RETURN_NONE;
 }
 

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -1102,28 +1102,29 @@ The disks must be in the format: [(path, offset), ... ]");
 static PyObject *
 py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
-    int rv, sanlockfd = -1, pid = -1;
-    const char *lockspace, *resource;
-    struct sanlk_resource *res;
+    int rv = -1, sanlockfd = -1, pid = -1;
+    PyObject *lockspace = NULL, *resource = NULL;
+    struct sanlk_resource *res = NULL;
     PyObject *disks;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "slkfd",
                                 "pid", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|ii", kwlist,
-        &lockspace, &resource, &PyList_Type, &disks, &sanlockfd, &pid)) {
-        return NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O&O&O!|ii", kwlist,
+        convert_to_pybytes, &lockspace, convert_to_pybytes, &resource,
+        &PyList_Type, &disks, &sanlockfd, &pid)) {
+        goto finally;
     }
 
     /* parse and check sanlock resource */
     if (__parse_resource(disks, &res) < 0) {
-        return NULL;
+        goto finally;
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* release sanlock resource (gil disabled) */
     Py_BEGIN_ALLOW_THREADS
@@ -1132,15 +1133,16 @@ py_release(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     if (rv != 0) {
         __set_exception(rv, "Sanlock resource not released");
-        goto exit_fail;
+        goto finally;
     }
 
+finally:
+    Py_XDECREF(lockspace);
+    Py_XDECREF(resource);
     free(res);
+    if (rv != 0)
+        return NULL;
     Py_RETURN_NONE;
-
-exit_fail:
-    free(res);
-    return NULL;
 }
 
 /* request */

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -1158,28 +1158,29 @@ The disks must be in the format: [(path, offset), ... ]");
 static PyObject *
 py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
-    int rv, action = SANLK_REQ_GRACEFUL, flags = 0;
-    const char *lockspace, *resource;
-    struct sanlk_resource *res;
+    int rv = -1, action = SANLK_REQ_GRACEFUL, flags = 0;
+    PyObject *lockspace = NULL, *resource = NULL;
+    struct sanlk_resource *res = NULL;
     PyObject *disks, *version = Py_None;
 
     static char *kwlist[] = {"lockspace", "resource", "disks", "action",
                                 "version", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "ssO!|iO", kwlist,
-        &lockspace, &resource, &PyList_Type, &disks, &action, &version)) {
-        return NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O&O&O!|iO", kwlist,
+        convert_to_pybytes, &lockspace, convert_to_pybytes, &resource,
+        &PyList_Type, &disks, &action, &version)) {
+        goto finally;
     }
 
     /* parse and check sanlock resource */
     if (__parse_resource(disks, &res) < 0) {
-        return NULL;
+        goto finally;
     }
 
     /* prepare sanlock names */
-    strncpy(res->lockspace_name, lockspace, SANLK_NAME_LEN);
-    strncpy(res->name, resource, SANLK_NAME_LEN);
+    strncpy(res->lockspace_name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
+    strncpy(res->name, PyBytes_AsString(resource), SANLK_NAME_LEN);
 
     /* prepare the resource version */
     if (version == Py_None) {
@@ -1189,7 +1190,7 @@ py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
         res->lver = pyinteger_as_unsigned_long_long_mask(version);
         if (res->lver == (uint64_t)-1) {
             __set_exception(EINVAL, "Unable to convert the version value");
-            goto exit_fail;
+            goto finally;
         }
     }
 
@@ -1200,15 +1201,16 @@ py_request(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     if (rv != 0) {
         __set_exception(rv, "Sanlock request not submitted");
-        goto exit_fail;
+        goto finally;
     }
 
+finally:
+    Py_XDECREF(lockspace);
+    Py_XDECREF(resource);
     free(res);
+    if (rv != 0)
+        return NULL;
     Py_RETURN_NONE;
-
-exit_fail:
-    free(res);
-    return NULL;
 }
 
 /* read_resource_owners */

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -982,34 +982,37 @@ timestamp and the io_timeout.\n");
 static PyObject *
 py_get_hosts(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
-    int rv, hss_count = 0;
+    int rv = -1, hss_count = 0;
     uint64_t host_id = 0;
-    const char *lockspace = NULL;
+    PyObject *lockspace = NULL;
     struct sanlk_host *hss = NULL;
     PyObject *ls_list = NULL;
 
     static char *kwlist[] = {"lockspace", "host_id", NULL};
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "s|k", kwlist,
-        &lockspace, &host_id)) {
-        return NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O&|k", kwlist,
+        convert_to_pybytes, &lockspace, &host_id)) {
+        goto finally;
     }
 
     /* get all the lockspaces (gil disabled) */
     Py_BEGIN_ALLOW_THREADS
-    rv = sanlock_get_hosts(lockspace, host_id, &hss, &hss_count, 0);
+    rv = sanlock_get_hosts(PyBytes_AsString(lockspace), host_id, &hss, &hss_count, 0);
     Py_END_ALLOW_THREADS
 
     if (rv < 0) {
         __set_exception(rv, "Sanlock get hosts failure");
-        goto exit_fail;
+        goto finally;
     }
 
     ls_list = __hosts_to_list(hss, hss_count);
 
-exit_fail:
-    if (hss) free(hss);
+finally:
+    Py_XDECREF(lockspace);
+    free(hss);
+    if (rv < 0)
+        return NULL;
     return ls_list;
 }
 

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -1616,29 +1616,33 @@ with -EBUSY error in this case.\n\
 static PyObject *
 py_set_event(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
-    const char *lockspace;
+    PyObject *lockspace = NULL;
     struct sanlk_host_event he = {0};
     uint32_t flags = 0;
-    int rv;
+    int rv = -1;
 
     static char *kwlist[] = {"lockspace", "host_id", "generation", "event",
                              "data", "flags", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "sKKK|KI", kwlist,
-        &lockspace, &he.host_id, &he.generation, &he.event, &he.data,
-        &flags)) {
-        return NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O&KKK|KI", kwlist,
+        convert_to_pybytes, &lockspace, &he.host_id, &he.generation, &he.event,
+        &he.data, &flags)) {
+        goto finally;
     }
 
     Py_BEGIN_ALLOW_THREADS
-    rv = sanlock_set_event(lockspace, &he, flags);
+    rv = sanlock_set_event(PyBytes_AsString(lockspace), &he, flags);
     Py_END_ALLOW_THREADS
 
     if (rv < 0) {
         __set_exception(rv, "Unable to set event");
-        return NULL;
+        goto finally;
     }
 
+finally:
+    Py_XDECREF(lockspace);
+    if (rv < 0)
+        return NULL;
     Py_RETURN_NONE;
 }
 

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -53,9 +53,7 @@ FILE_NAMES = [
 
 LOCKSPACE_OR_RESOURCE_NAMES = [
     # Bytes are supported with python 2 and 3.
-    pytest.param(
-        b"\xd7\x90",
-        marks=pytest.mark.xfail(six.PY3, reason="bytes support not implemented yet")),
+    pytest.param(b"\xd7\x90"),
     # Python 2 also supports str.
     pytest.param(
         "\xd7\x90",
@@ -66,7 +64,6 @@ LOCKSPACE_OR_RESOURCE_NAMES = [
         marks=pytest.mark.skipif(six.PY3, reason="python 3 supports only bytes")),
 ]
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("filename, encoding" , FILE_NAMES)
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
@@ -107,7 +104,6 @@ def test_write_lockspace(tmpdir, sanlock_daemon, filename, encoding, size, offse
     util.check_guard(path, size)
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("align", sanlock.ALIGN_SIZE)
 def test_write_lockspace_4k(user_4k_path, sanlock_daemon, align):
 
@@ -137,7 +133,6 @@ def test_write_lockspace_4k(user_4k_path, sanlock_daemon, align):
     util.check_guard(user_4k_path, align)
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_write_lockspace_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.write_lockspace(
@@ -155,7 +150,6 @@ def test_read_lockspace_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     assert e.value.errno == errno.EINVAL
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
@@ -204,7 +198,6 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
     util.check_guard(path, size)
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("align", sanlock.ALIGN_SIZE)
 def test_write_resource_4k(sanlock_daemon, user_4k_path, align):
     disks = [(user_4k_path, 0)]
@@ -250,7 +243,6 @@ def test_write_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     assert e.value.errno == errno.EINVAL
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_read_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     disks = [(user_4k_path, 0)]
 
@@ -266,7 +258,6 @@ def test_read_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     assert e.value.errno == errno.EINVAL
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_read_resource_owners_4k_invalid_sector_size(
         sanlock_daemon, user_4k_path):
     disks = [(user_4k_path, 0)]
@@ -284,7 +275,6 @@ def test_read_resource_owners_4k_invalid_sector_size(
     assert e.value.errno == errno.EINVAL
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_read_resource_owners_invalid_align_size(tmpdir, sanlock_daemon):
     path = str(tmpdir.join("path"))
     util.create_file(path, GiB)
@@ -307,7 +297,6 @@ def test_read_resource_owners_invalid_align_size(tmpdir, sanlock_daemon):
     assert e.value.errno == errno.EINVAL
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
     (MIN_RES_SIZE, 0),
@@ -352,7 +341,6 @@ def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset):
     assert lockspaces == []
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):
     path = str(tmpdir.join("ls_name"))
     util.create_file(path, MiB)
@@ -389,7 +377,6 @@ def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):
     assert acquired is False
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
     (MIN_RES_SIZE, 0),
@@ -463,7 +450,6 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
     assert owners == []
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("align, sector", [
     # Invalid alignment
     (KiB, sanlock.SECTOR_SIZE[0]),
@@ -479,7 +465,6 @@ def test_write_lockspace_invalid_align_sector(
         sanlock.write_lockspace(b"ls_name", path, align=align, sector=sector)
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("align, sector", [
     # Invalid alignment
     (KiB, sanlock.SECTOR_SIZE[0]),
@@ -497,7 +482,6 @@ def test_write_resource_invalid_align_sector(
             b"ls_name", b"res_name", disks, align=align, sector=sector)
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("disk", [
     # Not a tuple - unicode and bytes:
     "not a tuple",
@@ -552,7 +536,6 @@ def test_write_lockspace_parse_args(no_sanlock_daemon, name):
         sanlock.write_lockspace(name, "ls_path")
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
 def test_write_resource_parse_args(no_sanlock_daemon, name):
     with raises_sanlock_errno():
@@ -562,7 +545,6 @@ def test_write_resource_parse_args(no_sanlock_daemon, name):
         sanlock.write_resource(b"ls_name", name, [("disk_path",0)])
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
 def test_release_resource_parse_args(no_sanlock_daemon, name):
     with raises_sanlock_errno():
@@ -572,7 +554,6 @@ def test_release_resource_parse_args(no_sanlock_daemon, name):
         sanlock.release(b"ls_name", name, [("disk_path",0)])
 
 
-@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
 def test_read_resource_owners_parse_args(no_sanlock_daemon, name):
     with raises_sanlock_errno():

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -603,3 +603,8 @@ def test_reg_event_parse_args(no_sanlock_daemon, name):
 def test_end_event_parse_args(no_sanlock_daemon, name):
     with raises_sanlock_errno(errno.EALREADY):
         sanlock.end_event(-1, name)
+
+@pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
+def test_init_lockspace_parse_args(no_sanlock_daemon, name):
+    with raises_sanlock_errno(errno.ENODEV):
+        sanlock.init_lockspace(name, "path")

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -66,6 +66,7 @@ LOCKSPACE_OR_RESOURCE_NAMES = [
         marks=pytest.mark.skipif(six.PY3, reason="python 3 supports only bytes")),
 ]
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("filename, encoding" , FILE_NAMES)
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
@@ -78,22 +79,22 @@ def test_write_lockspace(tmpdir, sanlock_daemon, filename, encoding, size, offse
     util.create_file(path, size)
 
     # Test read and write with default alignment and sector size values.
-    sanlock.write_lockspace("name", path, offset=offset, iotimeout=1)
+    sanlock.write_lockspace(b"ls_name", path, offset=offset, iotimeout=1)
 
     ls = sanlock.read_lockspace(path, offset=offset)
-    assert ls == {"iotimeout": 1, "lockspace": b"name"}
+    assert ls == {"iotimeout": 1, "lockspace": b"ls_name"}
 
     # Test read and write with explicit alignment and sector size values.
     sanlock.write_lockspace(
-        "name", path, offset=offset, iotimeout=1, align=ALIGNMENT_1M,
+        b"ls_name", path, offset=offset, iotimeout=1, align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_512)
 
     ls = sanlock.read_lockspace(
         path, offset=offset, align=ALIGNMENT_1M, sector=SECTOR_SIZE_512)
-    assert ls == {"iotimeout": 1, "lockspace": b"name"}
+    assert ls == {"iotimeout": 1, "lockspace": b"ls_name"}
 
     acquired = sanlock.inq_lockspace(
-        "name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is False
 
     with io.open(path, "rb") as f:
@@ -106,6 +107,7 @@ def test_write_lockspace(tmpdir, sanlock_daemon, filename, encoding, size, offse
     util.check_guard(path, size)
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("align", sanlock.ALIGN_SIZE)
 def test_write_lockspace_4k(user_4k_path, sanlock_daemon, align):
 
@@ -116,14 +118,14 @@ def test_write_lockspace_4k(user_4k_path, sanlock_daemon, align):
     util.write_guard(user_4k_path, align)
 
     sanlock.write_lockspace(
-        "name", user_4k_path, iotimeout=1, align=align, sector=SECTOR_SIZE_4K)
+        b"ls_name", user_4k_path, iotimeout=1, align=align, sector=SECTOR_SIZE_4K)
 
     ls = sanlock.read_lockspace(
         user_4k_path, align=align, sector=SECTOR_SIZE_4K)
 
-    assert ls == {"iotimeout": 1, "lockspace": b"name"}
+    assert ls == {"iotimeout": 1, "lockspace": b"ls_name"}
 
-    acquired = sanlock.inq_lockspace("name", 1, user_4k_path, wait=False)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, user_4k_path, wait=False)
     assert acquired is False
 
     # Verify that lockspace was written.
@@ -135,22 +137,25 @@ def test_write_lockspace_4k(user_4k_path, sanlock_daemon, align):
     util.check_guard(user_4k_path, align)
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_write_lockspace_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.write_lockspace(
-            "name", user_4k_path, iotimeout=1, sector=SECTOR_SIZE_512)
+            b"ls_name", user_4k_path, iotimeout=1, sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_read_lockspace_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     sanlock.write_lockspace(
-        "name", user_4k_path, iotimeout=1, sector=SECTOR_SIZE_4K)
+        b"ls_name", user_4k_path, iotimeout=1, sector=SECTOR_SIZE_4K)
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.read_lockspace(user_4k_path, sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
@@ -164,7 +169,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
     disks = [(path, offset)]
 
     # Test read and write with default alignment and sector size values.
-    sanlock.write_resource("ls_name", "res_name", disks)
+    sanlock.write_resource(b"ls_name", b"res_name", disks)
 
     res = sanlock.read_resource(path, offset=offset)
     assert res == {
@@ -175,7 +180,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
 
     # Test read and write with explicit alignment and sector size values.
     sanlock.write_resource(
-        "ls_name", "res_name", disks, align=ALIGNMENT_1M,
+        b"ls_name", b"res_name", disks, align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_512)
 
     res = sanlock.read_resource(
@@ -186,7 +191,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
         "version": 0
     }
 
-    owners = sanlock.read_resource_owners("ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)
     assert owners == []
 
     with io.open(path, "rb") as f:
@@ -199,6 +204,7 @@ def test_write_resource(tmpdir, sanlock_daemon, filename, encoding, size, offset
     util.check_guard(path, size)
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("align", sanlock.ALIGN_SIZE)
 def test_write_resource_4k(sanlock_daemon, user_4k_path, align):
     disks = [(user_4k_path, 0)]
@@ -210,7 +216,7 @@ def test_write_resource_4k(sanlock_daemon, user_4k_path, align):
     util.write_guard(user_4k_path, align)
 
     sanlock.write_resource(
-        "ls_name", "res_name", disks, align=align, sector=SECTOR_SIZE_4K)
+        b"ls_name", b"res_name", disks, align=align, sector=SECTOR_SIZE_4K)
 
     res = sanlock.read_resource(
         user_4k_path, align=align, sector=SECTOR_SIZE_4K)
@@ -222,7 +228,7 @@ def test_write_resource_4k(sanlock_daemon, user_4k_path, align):
     }
 
     owners = sanlock.read_resource_owners(
-        "ls_name", "res_name", disks, align=align, sector=SECTOR_SIZE_4K)
+        b"ls_name", b"res_name", disks, align=align, sector=SECTOR_SIZE_4K)
     assert owners == []
 
     # Verify that resource was written.
@@ -240,16 +246,17 @@ def test_write_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.write_resource(
-            "ls_name", "res_name", disks, sector=SECTOR_SIZE_512)
+            b"ls_name", b"res_name", disks, sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_read_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     disks = [(user_4k_path, 0)]
 
     sanlock.write_resource(
-        "ls_name",
-        "res_name",
+        b"ls_name",
+        b"res_name",
         disks,
         align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_4K)
@@ -259,45 +266,48 @@ def test_read_resource_4k_invalid_sector_size(sanlock_daemon, user_4k_path):
     assert e.value.errno == errno.EINVAL
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_read_resource_owners_4k_invalid_sector_size(
         sanlock_daemon, user_4k_path):
     disks = [(user_4k_path, 0)]
 
     sanlock.write_resource(
-        "ls_name",
-        "res_name",
+        b"ls_name",
+        b"res_name",
         disks,
         align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_4K)
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.read_resource_owners(
-            "ls_name", "res_name", disks, sector=SECTOR_SIZE_512)
+            b"ls_name", b"res_name", disks, sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_read_resource_owners_invalid_align_size(tmpdir, sanlock_daemon):
     path = str(tmpdir.join("path"))
     util.create_file(path, GiB)
     disks = [(path, 0)]
 
     sanlock.write_resource(
-        "ls_name",
-        "res_name",
+        b"ls_name",
+        b"res_name",
         disks,
         align=ALIGNMENT_1M,
         sector=SECTOR_SIZE_512)
 
     with pytest.raises(sanlock.SanlockException) as e:
         sanlock.read_resource_owners(
-            "ls_name",
-            "res_name",
+            b"ls_name",
+            b"res_name",
             disks,
             align=ALIGNMENT_2M,
             sector=SECTOR_SIZE_512)
     assert e.value.errno == errno.EINVAL
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
     (MIN_RES_SIZE, 0),
@@ -308,18 +318,18 @@ def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset):
     path = str(tmpdir.join("ls_name"))
     util.create_file(path, size)
 
-    sanlock.write_lockspace("ls_name", path, offset=offset, iotimeout=1)
+    sanlock.write_lockspace(b"ls_name", path, offset=offset, iotimeout=1)
 
     # Since the lockspace is not acquired, we exepect to get False.
     acquired = sanlock.inq_lockspace(
-        "ls_name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is False
 
-    sanlock.add_lockspace("ls_name", 1, path, offset=offset, iotimeout=1)
+    sanlock.add_lockspace(b"ls_name", 1, path, offset=offset, iotimeout=1)
 
     # Once the lockspace is acquired, we exepect to get True.
     acquired = sanlock.inq_lockspace(
-        "ls_name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is True
 
     lockspaces = sanlock.get_lockspaces()
@@ -331,53 +341,55 @@ def test_add_rem_lockspace(tmpdir, sanlock_daemon, size, offset):
         'path': path
     }]
 
-    sanlock.rem_lockspace("ls_name", 1, path, offset=offset)
+    sanlock.rem_lockspace(b"ls_name", 1, path, offset=offset)
 
     # Once the lockspace is released, we exepect to get False.
     acquired = sanlock.inq_lockspace(
-        "ls_name", 1, path, offset=offset, wait=False)
+        b"ls_name", 1, path, offset=offset, wait=False)
     assert acquired is False
 
     lockspaces = sanlock.get_lockspaces()
     assert lockspaces == []
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 def test_add_rem_lockspace_async(tmpdir, sanlock_daemon):
     path = str(tmpdir.join("ls_name"))
     util.create_file(path, MiB)
 
-    sanlock.write_lockspace("ls_name", path, iotimeout=1)
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
+    sanlock.write_lockspace(b"ls_name", path, iotimeout=1)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=False)
     assert acquired is False
 
     # This will take 3 seconds.
-    sanlock.add_lockspace("ls_name", 1, path, iotimeout=1, **{"async": True})
+    sanlock.add_lockspace(b"ls_name", 1, path, iotimeout=1, **{"async": True})
 
     # While the lockspace is being aquired, we expect to get None.
     time.sleep(1)
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=False)
     assert acquired is None
 
     # Once the lockspace is acquired, we exepect to get True.
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=True)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=True)
     assert acquired is True
 
     # This will take about 3 seconds.
-    sanlock.rem_lockspace("ls_name", 1, path, **{"async": True})
+    sanlock.rem_lockspace(b"ls_name", 1, path, **{"async": True})
 
     # Wait until the lockspace change state from True to None.
-    while sanlock.inq_lockspace("ls_name", 1, path, wait=False):
+    while sanlock.inq_lockspace(b"ls_name", 1, path, wait=False):
         time.sleep(1)
 
     # While the lockspace is being released, we expect to get None.
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=False)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=False)
     assert acquired is None
 
     # Once the lockspace was released, we expect to get False.
-    acquired = sanlock.inq_lockspace("ls_name", 1, path, wait=True)
+    acquired = sanlock.inq_lockspace(b"ls_name", 1, path, wait=True)
     assert acquired is False
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("size,offset", [
     # Smallest offset.
     (MIN_RES_SIZE, 0),
@@ -391,20 +403,20 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
     res_path = str(tmpdir.join("res_name"))
     util.create_file(res_path, size)
 
-    sanlock.write_lockspace("ls_name", ls_path, offset=offset, iotimeout=1)
-    sanlock.add_lockspace("ls_name", 1, ls_path, offset=offset, iotimeout=1)
+    sanlock.write_lockspace(b"ls_name", ls_path, offset=offset, iotimeout=1)
+    sanlock.add_lockspace(b"ls_name", 1, ls_path, offset=offset, iotimeout=1)
 
     # Host status is not available until the first renewal.
     with pytest.raises(sanlock.SanlockException) as e:
-        sanlock.get_hosts("ls_name", 1)
+        sanlock.get_hosts(b"ls_name", 1)
     assert e.value.errno == errno.EAGAIN
 
     time.sleep(1)
-    host = sanlock.get_hosts("ls_name", 1)[0]
+    host = sanlock.get_hosts(b"ls_name", 1)[0]
     assert host["flags"] == sanlock.HOST_LIVE
 
     disks = [(res_path, offset)]
-    sanlock.write_resource("ls_name", "res_name", disks)
+    sanlock.write_resource(b"ls_name", b"res_name", disks)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -413,11 +425,11 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 0
     }
 
-    owners = sanlock.read_resource_owners("ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)
     assert owners == []
 
     fd = sanlock.register()
-    sanlock.acquire("ls_name", "res_name", disks, slkfd=fd)
+    sanlock.acquire(b"ls_name", b"res_name", disks, slkfd=fd)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -426,7 +438,7 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 1
     }
 
-    owner = sanlock.read_resource_owners("ls_name", "res_name", disks)[0]
+    owner = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)[0]
 
     assert owner["host_id"] == 1
     assert owner["flags"] == 0
@@ -434,11 +446,11 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
     assert owner["io_timeout"] == 0  # Why 0?
     # TODO: check timestamp.
 
-    host = sanlock.get_hosts("ls_name", 1)[0]
+    host = sanlock.get_hosts(b"ls_name", 1)[0]
     assert host["flags"] == sanlock.HOST_LIVE
     assert host["generation"] == owner["generation"]
 
-    sanlock.release("ls_name", "res_name", disks, slkfd=fd)
+    sanlock.release(b"ls_name", b"res_name", disks, slkfd=fd)
 
     res = sanlock.read_resource(res_path, offset=offset)
     assert res == {
@@ -447,10 +459,11 @@ def test_acquire_release_resource(tmpdir, sanlock_daemon, size, offset):
         "version": 1
     }
 
-    owners = sanlock.read_resource_owners("ls_name", "res_name", disks)
+    owners = sanlock.read_resource_owners(b"ls_name", b"res_name", disks)
     assert owners == []
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("align, sector", [
     # Invalid alignment
     (KiB, sanlock.SECTOR_SIZE[0]),
@@ -463,9 +476,10 @@ def test_write_lockspace_invalid_align_sector(
     util.create_file(path, LOCKSPACE_SIZE)
 
     with pytest.raises(ValueError):
-        sanlock.write_lockspace("name", path, align=align, sector=sector)
+        sanlock.write_lockspace(b"ls_name", path, align=align, sector=sector)
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("align, sector", [
     # Invalid alignment
     (KiB, sanlock.SECTOR_SIZE[0]),
@@ -480,9 +494,10 @@ def test_write_resource_invalid_align_sector(
 
     with pytest.raises(ValueError):
         sanlock.write_resource(
-            "ls_name", "res_name", disks, align=align, sector=sector)
+            b"ls_name", b"res_name", disks, align=align, sector=sector)
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("disk", [
     # Not a tuple - unicode and bytes:
     "not a tuple",
@@ -501,7 +516,7 @@ def test_write_resource_invalid_disk(tmpdir, sanlock_daemon, disk):
     # Test parsing disks list with invalid content.
     disks = [disk]
     with pytest.raises(ValueError) as e:
-        sanlock.write_resource("ls_name", "res_name", disks)
+        sanlock.write_resource(b"ls_name", b"res_name", disks)
     assert repr(disk) in str(e.value)
 
 
@@ -537,31 +552,34 @@ def test_write_lockspace_parse_args(no_sanlock_daemon, name):
         sanlock.write_lockspace(name, "ls_path")
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
 def test_write_resource_parse_args(no_sanlock_daemon, name):
     with raises_sanlock_errno():
-        sanlock.write_resource(name, "res_name", [("disk_path",0)])
+        sanlock.write_resource(name, b"res_name", [("disk_path",0)])
 
     with raises_sanlock_errno():
-        sanlock.write_resource("ls_name", name, [("disk_path",0)])
+        sanlock.write_resource(b"ls_name", name, [("disk_path",0)])
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
 def test_release_resource_parse_args(no_sanlock_daemon, name):
     with raises_sanlock_errno():
-        sanlock.release(name, "res_name", [("disk_path",0)])
+        sanlock.release(name, b"res_name", [("disk_path",0)])
 
     with raises_sanlock_errno():
-        sanlock.release("ls_name", name, [("disk_path",0)])
+        sanlock.release(b"ls_name", name, [("disk_path",0)])
 
 
+@pytest.mark.xfail(six.PY3, reason="lockspace/resource names in bytes are unsupported yet")
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
 def test_read_resource_owners_parse_args(no_sanlock_daemon, name):
     with raises_sanlock_errno():
-        sanlock.read_resource_owners(name, "res_name", [("disk_path",0)])
+        sanlock.read_resource_owners(name, b"res_name", [("disk_path",0)])
 
     with raises_sanlock_errno():
-        sanlock.read_resource_owners("ls_name", name, [("disk_path",0)])
+        sanlock.read_resource_owners(b"ls_name", name, [("disk_path",0)])
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -608,3 +608,11 @@ def test_end_event_parse_args(no_sanlock_daemon, name):
 def test_init_lockspace_parse_args(no_sanlock_daemon, name):
     with raises_sanlock_errno(errno.ENODEV):
         sanlock.init_lockspace(name, "path")
+
+@pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
+def test_init_resource_parse_args(no_sanlock_daemon, name):
+    disks = [("path",0)]
+    with raises_sanlock_errno(errno.ENOENT):
+        sanlock.init_resource(b"ls_name", name, disks)
+    with raises_sanlock_errno(errno.ENOENT):
+        sanlock.init_resource(name, b"res_name", disks)

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -605,6 +605,11 @@ def test_end_event_parse_args(no_sanlock_daemon, name):
         sanlock.end_event(-1, name)
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
+def test_set_event_parse_args(no_sanlock_daemon, name):
+    with raises_sanlock_errno():
+        sanlock.set_event(name, 1, 1, 1)
+
+@pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
 def test_init_lockspace_parse_args(no_sanlock_daemon, name):
     with raises_sanlock_errno(errno.ENODEV):
         sanlock.init_lockspace(name, "path")


### PR DESCRIPTION
PR outline:
1. set hardcoded ls_names and res_names as bytes in tests.
2. shut tests involving lockspace or resource names as bytes as xfail for py3.
3. add pybytes converter to sanlock.c 
4. go over API and apply parser per each lockspace/resource API call in a dedicated patch for easy review.
5. re-enable xfail tests for py3.