### PR TITLE
Parse paths as unicode strings or bytes

### DIFF
--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -813,7 +813,7 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     int rv = -1, async = 0, flags = 0;
     uint32_t iotimeout = 0;
     PyObject *lockspace = NULL;
-    const char *path;
+    PyObject *path = NULL;
     struct sanlk_lockspace ls;
 
     static char *kwlist[] = {"lockspace", "host_id", "path", "offset",
@@ -823,9 +823,9 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O&ks|kIi", kwlist,
-        convert_to_pybytes, &lockspace, &ls.host_id, &path, &ls.host_id_disk.offset,
-        &iotimeout, &async)) {
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O&kO&|kIi", kwlist,
+        convert_to_pybytes, &lockspace, &ls.host_id, pypath_converter, &path,
+        &ls.host_id_disk.offset, &iotimeout, &async)) {
         goto finally;
     }
 
@@ -836,7 +836,7 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
     /* prepare sanlock names */
     strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(ls.host_id_disk.path, path, SANLK_PATH_LEN - 1);
+    strncpy(ls.host_id_disk.path, PyBytes_AsString(path), SANLK_PATH_LEN - 1);
 
     /* add sanlock lockspace (gil disabled) */
     Py_BEGIN_ALLOW_THREADS
@@ -850,6 +850,7 @@ py_add_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
 finally:
     Py_XDECREF(lockspace);
+    Py_XDECREF(path);
     if (rv != 0 )
         return NULL;
     Py_RETURN_NONE;

--- a/python/sanlock.c
+++ b/python/sanlock.c
@@ -933,7 +933,7 @@ py_rem_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 {
     int rv = -1, async = 0, unused = 0, flags = 0;
     PyObject *lockspace = NULL;
-    const char *path;
+    PyObject *path = NULL;
     struct sanlk_lockspace ls;
 
     static char *kwlist[] = {"lockspace", "host_id", "path", "offset",
@@ -943,15 +943,16 @@ py_rem_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
     memset(&ls, 0, sizeof(struct sanlk_lockspace));
 
     /* parse python tuple */
-    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O&ks|kii", kwlist,
-        convert_to_pybytes, &lockspace, &ls.host_id, &path, &ls.host_id_disk.offset,
+    if (!PyArg_ParseTupleAndKeywords(args, keywds, "O&kO&|kii", kwlist,
+        convert_to_pybytes, &lockspace, &ls.host_id, pypath_converter, &path,
+        &ls.host_id_disk.offset,
         &async, &unused)) {
         goto finally;
     }
 
     /* prepare sanlock names */
     strncpy(ls.name, PyBytes_AsString(lockspace), SANLK_NAME_LEN);
-    strncpy(ls.host_id_disk.path, path, SANLK_PATH_LEN - 1);
+    strncpy(ls.host_id_disk.path, PyBytes_AsString(path), SANLK_PATH_LEN - 1);
 
     /* prepare sanlock_rem_lockspace flags */
     if (async) {
@@ -974,6 +975,7 @@ py_rem_lockspace(PyObject *self __unused, PyObject *args, PyObject *keywds)
 
 finally:
     Py_XDECREF(lockspace);
+    Py_XDECREF(path);
     if (rv != 0)
         return NULL;
     Py_RETURN_NONE;

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -51,6 +51,14 @@ FILE_NAMES = [
             reason="currently not supporting bytes paths")),
 ]
 
+FILE_NAMES_NO_XFAILS = [
+    #name, encoding
+    ("ascii", None),
+    (u"ascii", None),
+    (u"\u05d0", None),
+    (u"\u05d0", "utf-8"),
+]
+
 LOCKSPACE_OR_RESOURCE_NAMES = [
     # Bytes are supported with python 2 and 3.
     pytest.param(b"\xd7\x90"),
@@ -543,7 +551,7 @@ def test_write_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_write_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     disks = [(path, 0)]
@@ -555,7 +563,7 @@ def test_write_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_release_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     disks = [(path, 0)]
@@ -567,7 +575,7 @@ def test_release_resource_parse_args(no_sanlock_daemon, name, filename, encoding
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_read_resource_owners_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     disks = [(path, 0)]
@@ -619,7 +627,7 @@ def test_init_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_init_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     disks = [(path, 0)]

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -642,7 +642,7 @@ def test_get_alignment_parse_args(no_sanlock_daemon, filename, encoding):
     with raises_sanlock_errno(errno.ENOENT):
         sanlock.get_alignment(path)
 
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_read_lockspace_parse_args(no_sanlock_daemon, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -619,7 +619,7 @@ def test_set_event_parse_args(no_sanlock_daemon, name):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_init_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno(errno.ENODEV):

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -648,7 +648,7 @@ def test_read_lockspace_parse_args(no_sanlock_daemon, filename, encoding):
     with raises_sanlock_errno():
         sanlock.read_lockspace(path)
 
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_read_resource_parse_args(no_sanlock_daemon, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -535,7 +535,7 @@ def test_rem_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_add_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -527,7 +527,7 @@ def raises_sanlock_errno(expected_errno=errno.ECONNREFUSED):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_rem_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -636,7 +636,7 @@ def test_init_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
     with raises_sanlock_errno(errno.ENOENT):
         sanlock.init_resource(name, b"res_name", disks)
 
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_get_alignment_parse_args(no_sanlock_daemon, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno(errno.ENOENT):

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -512,7 +512,7 @@ def test_write_resource_invalid_disk(tmpdir, sanlock_daemon, disk):
     assert repr(disk) in str(e.value)
 
 
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_killpath(tmpdir, sanlock_daemon, filename, encoding):
     cmd_path = util.generate_path(tmpdir, filename, encoding)
     fd = sanlock.register()

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -39,22 +39,6 @@ FILE_NAMES = [
     #name, encoding
     ("ascii", None),
     (u"ascii", None),
-    pytest.param(
-        u"\u05d0", None,
-        marks=pytest.mark.xfail(
-            six.PY2,
-            reason="currently not supporting non-ascii paths")),
-    pytest.param(
-        u"\u05d0", "utf-8",
-        marks=pytest.mark.xfail(
-            six.PY3,
-            reason="currently not supporting bytes paths")),
-]
-
-FILE_NAMES_NO_XFAILS = [
-    #name, encoding
-    ("ascii", None),
-    (u"ascii", None),
     (u"\u05d0", None),
     (u"\u05d0", "utf-8"),
 ]
@@ -512,7 +496,7 @@ def test_write_resource_invalid_disk(tmpdir, sanlock_daemon, disk):
     assert repr(disk) in str(e.value)
 
 
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_killpath(tmpdir, sanlock_daemon, filename, encoding):
     cmd_path = util.generate_path(tmpdir, filename, encoding)
     fd = sanlock.register()
@@ -527,7 +511,7 @@ def raises_sanlock_errno(expected_errno=errno.ECONNREFUSED):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_rem_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():
@@ -535,7 +519,7 @@ def test_rem_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_add_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():
@@ -543,7 +527,7 @@ def test_add_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_write_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():
@@ -551,7 +535,7 @@ def test_write_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_write_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     disks = [(path, 0)]
@@ -563,7 +547,7 @@ def test_write_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_release_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     disks = [(path, 0)]
@@ -575,7 +559,7 @@ def test_release_resource_parse_args(no_sanlock_daemon, name, filename, encoding
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_read_resource_owners_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     disks = [(path, 0)]
@@ -593,7 +577,7 @@ def test_get_hosts_parse_args(no_sanlock_daemon, name):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_inq_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():
@@ -619,7 +603,7 @@ def test_set_event_parse_args(no_sanlock_daemon, name):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_init_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno(errno.ENODEV):
@@ -627,7 +611,7 @@ def test_init_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_init_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     disks = [(path, 0)]
@@ -636,19 +620,19 @@ def test_init_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
     with raises_sanlock_errno(errno.ENOENT):
         sanlock.init_resource(name, b"res_name", disks)
 
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_get_alignment_parse_args(no_sanlock_daemon, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno(errno.ENOENT):
         sanlock.get_alignment(path)
 
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_read_lockspace_parse_args(no_sanlock_daemon, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():
         sanlock.read_lockspace(path)
 
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
 def test_read_resource_parse_args(no_sanlock_daemon, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -519,48 +519,63 @@ def raises_sanlock_errno(expected_errno=errno.ECONNREFUSED):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-def test_rem_lockspace_parse_args(no_sanlock_daemon, name):
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_rem_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():
-        sanlock.rem_lockspace(name, 1, "ls_path", 0)
+        sanlock.rem_lockspace(name, 1, path, 0)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-def test_add_lockspace_parse_args(no_sanlock_daemon, name):
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_add_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():
-        sanlock.add_lockspace(name, 1, "ls_path", 0)
+        sanlock.add_lockspace(name, 1, path, 0)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-def test_write_lockspace_parse_args(no_sanlock_daemon, name):
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_write_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():
-        sanlock.write_lockspace(name, "ls_path")
+        sanlock.write_lockspace(name, path)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-def test_write_resource_parse_args(no_sanlock_daemon, name):
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_write_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
+    disks = [(path, 0)]
     with raises_sanlock_errno():
-        sanlock.write_resource(name, b"res_name", [("disk_path",0)])
+        sanlock.write_resource(name, b"res_name", disks)
 
     with raises_sanlock_errno():
-        sanlock.write_resource(b"ls_name", name, [("disk_path",0)])
+        sanlock.write_resource(b"ls_name", name, disks)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-def test_release_resource_parse_args(no_sanlock_daemon, name):
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_release_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
+    disks = [(path, 0)]
     with raises_sanlock_errno():
-        sanlock.release(name, b"res_name", [("disk_path",0)])
+        sanlock.release(name, b"res_name", disks)
 
     with raises_sanlock_errno():
-        sanlock.release(b"ls_name", name, [("disk_path",0)])
+        sanlock.release(b"ls_name", name, disks)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-def test_read_resource_owners_parse_args(no_sanlock_daemon, name):
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_read_resource_owners_parse_args(no_sanlock_daemon, name, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
+    disks = [(path, 0)]
     with raises_sanlock_errno():
-        sanlock.read_resource_owners(name, b"res_name", [("disk_path",0)])
+        sanlock.read_resource_owners(name, b"res_name", disks)
 
     with raises_sanlock_errno():
-        sanlock.read_resource_owners(b"ls_name", name, [("disk_path",0)])
+        sanlock.read_resource_owners(b"ls_name", name, disks)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
@@ -570,9 +585,11 @@ def test_get_hosts_parse_args(no_sanlock_daemon, name):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-def test_inq_lockspace_parse_args(no_sanlock_daemon, name):
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_inq_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():
-        sanlock.inq_lockspace(name, 1, "path", wait=False)
+        sanlock.inq_lockspace(name, 1, path, wait=False)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
@@ -594,15 +611,38 @@ def test_set_event_parse_args(no_sanlock_daemon, name):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-def test_init_lockspace_parse_args(no_sanlock_daemon, name):
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_init_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno(errno.ENODEV):
-        sanlock.init_lockspace(name, "path")
+        sanlock.init_lockspace(name, path)
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-def test_init_resource_parse_args(no_sanlock_daemon, name):
-    disks = [("path", 0)]
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_init_resource_parse_args(no_sanlock_daemon, name, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
+    disks = [(path, 0)]
     with raises_sanlock_errno(errno.ENOENT):
         sanlock.init_resource(b"ls_name", name, disks)
     with raises_sanlock_errno(errno.ENOENT):
         sanlock.init_resource(name, b"res_name", disks)
+
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_get_alignment_parse_args(no_sanlock_daemon, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
+    with raises_sanlock_errno(errno.ENOENT):
+        sanlock.get_alignment(path)
+
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_read_lockspace_parse_args(no_sanlock_daemon, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
+    with raises_sanlock_errno():
+        sanlock.read_lockspace(path)
+
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+def test_read_resource_parse_args(no_sanlock_daemon, filename, encoding):
+    path = util.generate_path("/tmp/", filename, encoding)
+    with raises_sanlock_errno():
+        sanlock.read_resource(path)
+

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -593,7 +593,7 @@ def test_get_hosts_parse_args(no_sanlock_daemon, name):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_inq_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():

--- a/tests/python_test.py
+++ b/tests/python_test.py
@@ -543,7 +543,7 @@ def test_add_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
 
 
 @pytest.mark.parametrize("name", LOCKSPACE_OR_RESOURCE_NAMES)
-@pytest.mark.parametrize("filename,encoding", FILE_NAMES)
+@pytest.mark.parametrize("filename,encoding", FILE_NAMES_NO_XFAILS)
 def test_write_lockspace_parse_args(no_sanlock_daemon, name, filename, encoding):
     path = util.generate_path("/tmp/", filename, encoding)
     with raises_sanlock_errno():


### PR DESCRIPTION
We would like to preserve Python 2 handle of paths as either unicode (ascii) strings or bytes.
We apply path converter for accepting PyObject and detecting if its either given as bytes or if its given as unicode. In the latter case we convert the unicode string to its bytes encoding and treat path internally as bytes throughout sanlock API. Tests are added and modified accordingly.